### PR TITLE
feat: add CHANGELOG generation step to lifecycle (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the spec-driven plugin.
 
+## [1.9.0] - 2026-02-20
+
+### Added
+- **CHANGELOG generation step** — new inline lifecycle step that auto-generates a Keep a Changelog entry from the feature branch's git commits. Parses conventional commit prefixes (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`), categorizes entries, and presents for user approval before writing to `CHANGELOG.md`. Falls back to a single "Changes" section for non-conventional commits. Supports version detection from `package.json`, `Cargo.toml`, `pyproject.toml`, `mix.exs`, and git tags. Merges into existing `[Unreleased]` sections without overwriting.
+- Step added to Small enhancement (step 12), Feature (step 13), and Major feature (step 14) lifecycles. Quick fix is unchanged.
+
+### Changed
+- start-feature step lists updated: Small enhancement (14 steps, was 13), Feature (15 steps, was 14), Major feature (16 steps, was 15)
+
 ## [1.8.0] - 2026-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ spec-driven owns the design and verification phases. superpowers owns implementa
 | Implement (TDD) | superpowers | `test-driven-development` |
 | Self-review | **spec-driven** (inline) | Reviews code against `coding-standards.md` checklist |
 | Code review | **spec-driven** (inline) | Multi-agent review pipeline (7 agents, auto-fix, re-verify loop) |
+| Generate CHANGELOG entry | **spec-driven** (inline) | Parses branch commits, generates Keep a Changelog entry |
 | Final verification | **spec-driven** + superpowers | `verify-acceptance-criteria` + `verification-before-completion` |
 | Commit and PR | superpowers | `finishing-a-development-branch` |
 
@@ -164,11 +165,12 @@ Skills that need project context (`design-verification`, `spike`) will auto-crea
 12b. Device Matrix Testing         ← mobile only
 13. Self-Review                    ← inline (coding-standards.md checklist)
 14. Code Review                    ← inline (multi-agent pipeline: find → fix → re-verify)
-15. Final Verification             ← verify-acceptance-criteria + superpowers:verification-before-completion
-15b. Beta Testing                  ← mobile only (TestFlight / Play Console)
-16. PR / Merge                     ← superpowers:finishing-a-development-branch
-16b. App Store Review              ← mobile only
-17. Deploy
+15. Generate CHANGELOG Entry       ← inline (conventional commits → Keep a Changelog)
+16. Final Verification             ← verify-acceptance-criteria + superpowers:verification-before-completion
+16b. Beta Testing                  ← mobile only (TestFlight / Play Console)
+17. PR / Merge                     ← superpowers:finishing-a-development-branch
+17b. App Store Review              ← mobile only
+18. Deploy
 ```
 
 ## Hooks

--- a/docs/plans/2026-02-20-changelog-generation-plan.md
+++ b/docs/plans/2026-02-20-changelog-generation-plan.md
@@ -1,0 +1,442 @@
+# CHANGELOG Generation from Commits — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an inline "Generate CHANGELOG entry" step to the start-feature lifecycle that auto-generates a Keep a Changelog entry from the feature branch's git commits.
+
+**Architecture:** New inline step in `skills/start-feature/SKILL.md`, inserted after Code Review Pipeline Step. Step lists for Small enhancement, Feature, and Major feature are updated with the new step and renumbered. README lifecycle table and diagram updated to match.
+
+**Tech Stack:** Markdown (SKILL.md, README.md, CHANGELOG.md) — no runtime code, no tests to write.
+
+---
+
+### Task 1: Update step lists in SKILL.md
+
+Add "Generate CHANGELOG entry" to Small enhancement, Feature, and Major feature step lists. Renumber Final verification and Commit and PR in each.
+
+**Files:**
+- Modify: `skills/start-feature/SKILL.md:159-211`
+
+**Step 1: Edit Small enhancement step list (lines 159-174)**
+
+Replace:
+```markdown
+**Small enhancement:**
+```
+- [ ] 1. Brainstorm requirements
+- [ ] 2. Documentation lookup (Context7)
+- [ ] 3. Design document
+- [ ] 4. Create issue
+- [ ] 5. Implementation plan
+- [ ] 6. Verify plan criteria
+- [ ] 7. Worktree setup
+- [ ] 8. Study existing patterns
+- [ ] 9. Implement (TDD)
+- [ ] 10. Self-review
+- [ ] 11. Code review
+- [ ] 12. Final verification
+- [ ] 13. Commit and PR
+```
+```
+
+With:
+```markdown
+**Small enhancement:**
+```
+- [ ] 1. Brainstorm requirements
+- [ ] 2. Documentation lookup (Context7)
+- [ ] 3. Design document
+- [ ] 4. Create issue
+- [ ] 5. Implementation plan
+- [ ] 6. Verify plan criteria
+- [ ] 7. Worktree setup
+- [ ] 8. Study existing patterns
+- [ ] 9. Implement (TDD)
+- [ ] 10. Self-review
+- [ ] 11. Code review
+- [ ] 12. Generate CHANGELOG entry
+- [ ] 13. Final verification
+- [ ] 14. Commit and PR
+```
+```
+
+**Step 2: Edit Feature step list (lines 176-192)**
+
+Replace:
+```markdown
+**Feature:**
+```
+- [ ] 1. Brainstorm requirements
+- [ ] 2. Documentation lookup (Context7)
+- [ ] 3. Design document
+- [ ] 4. Design verification
+- [ ] 5. Create issue
+- [ ] 6. Implementation plan
+- [ ] 7. Verify plan criteria
+- [ ] 8. Worktree setup
+- [ ] 9. Study existing patterns
+- [ ] 10. Implement (TDD)
+- [ ] 11. Self-review
+- [ ] 12. Code review
+- [ ] 13. Final verification
+- [ ] 14. Commit and PR
+```
+```
+
+With:
+```markdown
+**Feature:**
+```
+- [ ] 1. Brainstorm requirements
+- [ ] 2. Documentation lookup (Context7)
+- [ ] 3. Design document
+- [ ] 4. Design verification
+- [ ] 5. Create issue
+- [ ] 6. Implementation plan
+- [ ] 7. Verify plan criteria
+- [ ] 8. Worktree setup
+- [ ] 9. Study existing patterns
+- [ ] 10. Implement (TDD)
+- [ ] 11. Self-review
+- [ ] 12. Code review
+- [ ] 13. Generate CHANGELOG entry
+- [ ] 14. Final verification
+- [ ] 15. Commit and PR
+```
+```
+
+**Step 3: Edit Major feature step list (lines 194-211)**
+
+Replace:
+```markdown
+**Major feature:**
+```
+- [ ] 1. Brainstorm requirements
+- [ ] 2. Spike / PoC (if risky unknowns)
+- [ ] 3. Documentation lookup (Context7)
+- [ ] 4. Design document
+- [ ] 5. Design verification
+- [ ] 6. Create issue
+- [ ] 7. Implementation plan
+- [ ] 8. Verify plan criteria
+- [ ] 9. Worktree setup
+- [ ] 10. Study existing patterns
+- [ ] 11. Implement (TDD)
+- [ ] 12. Self-review
+- [ ] 13. Code review
+- [ ] 14. Final verification
+- [ ] 15. Commit and PR
+```
+```
+
+With:
+```markdown
+**Major feature:**
+```
+- [ ] 1. Brainstorm requirements
+- [ ] 2. Spike / PoC (if risky unknowns)
+- [ ] 3. Documentation lookup (Context7)
+- [ ] 4. Design document
+- [ ] 5. Design verification
+- [ ] 6. Create issue
+- [ ] 7. Implementation plan
+- [ ] 8. Verify plan criteria
+- [ ] 9. Worktree setup
+- [ ] 10. Study existing patterns
+- [ ] 11. Implement (TDD)
+- [ ] 12. Self-review
+- [ ] 13. Code review
+- [ ] 14. Generate CHANGELOG entry
+- [ ] 15. Final verification
+- [ ] 16. Commit and PR
+```
+```
+
+**Step 4: Verify step lists**
+
+Confirm each step list has the correct count:
+- Quick fix: 6 steps (unchanged)
+- Small enhancement: 14 steps (was 13)
+- Feature: 15 steps (was 14)
+- Major feature: 16 steps (was 15)
+
+**Acceptance Criteria:**
+- [ ] Small enhancement step list contains "Generate CHANGELOG entry" as step 12, Final verification as step 13, Commit and PR as step 14 (14 total steps)
+- [ ] Feature step list contains "Generate CHANGELOG entry" as step 13, Final verification as step 14, Commit and PR as step 15 (15 total steps)
+- [ ] Major feature step list contains "Generate CHANGELOG entry" as step 14, Final verification as step 15, Commit and PR as step 16 (16 total steps)
+- [ ] Quick fix step list is unchanged (6 steps, no CHANGELOG step)
+- [ ] The string "Generate CHANGELOG entry" appears exactly 3 times in the step list sections (lines 149-211) of `skills/start-feature/SKILL.md` — one per non-quickfix scope
+
+---
+
+### Task 2: Add Generate CHANGELOG entry to Skill Mapping table
+
+Add a new row to the Skill Mapping table for the Generate CHANGELOG entry step.
+
+**Files:**
+- Modify: `skills/start-feature/SKILL.md:241-260`
+
+**Step 1: Add row to Skill Mapping table**
+
+Insert a new row after the "Code review" row (line 255) and before "Final verification" (line 256):
+
+```markdown
+| Generate CHANGELOG entry | No skill — inline step (see below) | CHANGELOG.md updated with categorized entry |
+```
+
+The table should now look like:
+```markdown
+| Self-review | No skill — inline step (see below) | Code verified against coding standards before formal review |
+| Code review | No skill — inline step (see below) | All Critical/Important findings fixed, tests pass |
+| Generate CHANGELOG entry | No skill — inline step (see below) | CHANGELOG.md updated with categorized entry |
+| Final verification | `spec-driven:verify-acceptance-criteria` + `superpowers:verification-before-completion` | All criteria PASS + lint/typecheck/build pass |
+```
+
+**Acceptance Criteria:**
+- [ ] Skill Mapping table contains a "Generate CHANGELOG entry" row with skill "No skill — inline step (see below)" and expected output "CHANGELOG.md updated with categorized entry"
+- [ ] The row appears between "Code review" and "Final verification"
+
+---
+
+### Task 3: Write the Generate CHANGELOG Entry Step inline section
+
+Add the full inline step section to SKILL.md after the Code Review Pipeline Step section (which ends around line 471) and before the Documentation Lookup Step section (which starts around line 472).
+
+**Files:**
+- Modify: `skills/start-feature/SKILL.md` (insert after line 471, before `### Documentation Lookup Step`)
+
+**Step 1: Write the inline section**
+
+Insert the following section between the Code Review Pipeline Step's closing output block and the Documentation Lookup Step header:
+
+```markdown
+### Generate CHANGELOG Entry Step (inline — no separate skill)
+
+This step runs after code review and before final verification. It auto-generates a CHANGELOG entry from the feature branch's git commits and presents it for user approval before writing. It runs for all scopes except Quick fix.
+
+**Process:**
+
+#### Phase 1: Collect commits
+
+1. Get all commit messages on the feature branch: `git log --format="%s" main...HEAD`
+2. Filter out merge commits matching `^Merge (branch|pull request)`
+3. Filter out fixup/squash commits matching `^(fixup|squash)!`
+4. If no commits remain after filtering, skip the step: "No commits found on feature branch — skipping CHANGELOG generation."
+
+#### Phase 2: Categorize by conventional commit prefix
+
+For each commit message, match against these prefixes:
+
+| Prefix | Keep a Changelog Category |
+|--------|--------------------------|
+| `feat:` | Added |
+| `fix:` | Fixed |
+| `refactor:` | Changed |
+| `docs:` | Documentation |
+| `test:` | Testing |
+| `chore:` | Maintenance |
+
+**Processing rules:**
+1. Match prefix case-insensitively: `feat:`, `Feat:`, `FEAT:` all match
+2. Strip the prefix and optional scope: `feat(csv): add export` → `Add export`
+3. Capitalize the first letter of the remaining message
+4. Deduplicate entries with identical messages (case-insensitive, keep first occurrence)
+5. If no commits match any prefix, put all entries under a single `### Changes` category
+6. Omit empty categories from the output
+
+#### Phase 3: Detect version (optional)
+
+Check these sources in order, use the first one found:
+
+1. `package.json` → `version` field
+2. `Cargo.toml` → `[package]` section `version` field
+3. `pyproject.toml` → `[project]` section `version` field
+4. `mix.exs` → `@version` attribute
+5. Latest git tag matching semver pattern: `git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | head -1`
+
+If a version is detected, present it alongside `[Unreleased]` via `AskUserQuestion`:
+- **Option 1:** `[Unreleased]` (Recommended) — assign version at release time
+- **Option 2:** `[X.Y.Z] - YYYY-MM-DD` — use detected version now
+
+If no version detected, use `[Unreleased]` without asking.
+
+#### Phase 4: Generate entry
+
+Format the entry in Keep a Changelog format:
+
+```
+## [Unreleased]
+
+### Added
+- Entry from feat: commit
+- Entry from feat: commit
+
+### Fixed
+- Entry from fix: commit
+
+### Changed
+- Entry from refactor: commit
+```
+
+Category order: Added, Fixed, Changed, Documentation, Testing, Maintenance, Changes (fallback last).
+
+#### Phase 5: Present for approval
+
+Present the generated entry to the user via `AskUserQuestion`:
+
+- **Option 1:** "Looks good — write it" — proceed to write
+- **Option 2:** "Let me edit" — user provides corrections in freeform text, entry is revised
+- **Option 3:** "Skip CHANGELOG" — announce risk: "No CHANGELOG entry will be included in this PR. You may want to add one manually." Proceed to next lifecycle step.
+
+#### Phase 6: Write to CHANGELOG.md
+
+**If CHANGELOG.md exists with an `[Unreleased]` section:**
+1. Parse existing categories under `[Unreleased]`
+2. For each generated category:
+   - If the category exists in the file, append new entries at the end of that category's list
+   - If the category doesn't exist, add it after the last existing category under `[Unreleased]`
+3. Deduplicate: skip any generated entry that matches an existing entry (case-insensitive)
+4. Preserve all existing entries — never remove or reorder them
+
+**If CHANGELOG.md exists without `[Unreleased]`:**
+1. Find the first `## [` heading (the latest version section)
+2. Insert the new `## [Unreleased]` section before it
+
+**If no CHANGELOG.md exists:**
+1. Create the file with the Keep a Changelog header:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+[generated categories and entries]
+```
+
+After writing, announce: "CHANGELOG.md updated with N entries across M categories."
+
+**Output format:**
+```
+## CHANGELOG Generation Results
+
+**Version heading:** [Unreleased] (or [X.Y.Z] - YYYY-MM-DD)
+**Commits parsed:** N
+**Entries generated:** M (after dedup)
+**Categories:** [list]
+**Action:** Written to CHANGELOG.md / Skipped by user
+```
+```
+
+**Step 2: Verify the section is correctly placed**
+
+The section should appear:
+- After the Code Review Pipeline Step section (ends with the `**Status:** Clean / N issues remaining` output block)
+- Before the Documentation Lookup Step section (`### Documentation Lookup Step`)
+
+**Acceptance Criteria:**
+- [ ] `skills/start-feature/SKILL.md` contains a section titled "### Generate CHANGELOG Entry Step (inline — no separate skill)"
+- [ ] The section appears after "Code Review Pipeline Step" and before "Documentation Lookup Step"
+- [ ] The section contains Phase 1 through Phase 6 with all rules from the design doc
+- [ ] Commit categorization table lists all 6 conventional commit prefixes plus the fallback
+- [ ] Version detection lists all 5 sources (package.json, Cargo.toml, pyproject.toml, mix.exs, git tags)
+- [ ] User approval flow has 3 options: approve, edit, skip
+- [ ] Three CHANGELOG.md scenarios are documented: existing with [Unreleased], existing without, new file
+- [ ] Merge rules specify: append to existing categories, add new categories after last existing, deduplicate case-insensitively, never remove or reorder
+
+---
+
+### Task 4: Update README.md lifecycle table
+
+Add the Generate CHANGELOG entry row to the lifecycle table in README.md.
+
+**Files:**
+- Modify: `README.md:87-103`
+
+**Step 1: Add row to lifecycle table**
+
+Insert between "Code review" (line 101) and "Final verification" (line 102):
+
+```markdown
+| Generate CHANGELOG entry | **spec-driven** (inline) | Parses branch commits, generates Keep a Changelog entry |
+```
+
+**Acceptance Criteria:**
+- [ ] README.md lifecycle table contains a "Generate CHANGELOG entry" row
+- [ ] Plugin column shows `**spec-driven** (inline)`
+- [ ] Row appears between "Code review" and "Final verification"
+
+---
+
+### Task 5: Update README.md lifecycle diagram
+
+Add the Generate CHANGELOG entry step to the numbered lifecycle diagram in README.md.
+
+**Files:**
+- Modify: `README.md:151-172`
+
+**Step 1: Insert new step and renumber**
+
+The `b` suffix pattern in the diagram is for "mobile only" steps. CHANGELOG applies to all non-quickfix scopes, so it gets a full number. Insert step 15 and renumber everything after it:
+
+```
+14. Code Review                    ← inline (multi-agent pipeline: find → fix → re-verify)
+15. Generate CHANGELOG Entry       ← inline (conventional commits → Keep a Changelog)
+16. Final Verification             ← verify-acceptance-criteria + superpowers:verification-before-completion
+16b. Beta Testing                  ← mobile only (TestFlight / Play Console)
+17. PR / Merge                     ← superpowers:finishing-a-development-branch
+17b. App Store Review              ← mobile only
+18. Deploy
+```
+
+**Acceptance Criteria:**
+- [ ] README.md lifecycle diagram contains "Generate CHANGELOG Entry" as step 15
+- [ ] It appears after "Code Review" (step 14) and before "Final Verification" (step 16)
+- [ ] Final Verification is step 16, PR / Merge is step 17, Deploy is step 18
+- [ ] Mobile-only steps use correct parent numbers: 12b (Device Matrix Testing), 16b (Beta Testing), 17b (App Store Review)
+
+---
+
+### Task 6: Update CHANGELOG.md
+
+Add entry for this feature under the next version.
+
+**Files:**
+- Modify: `CHANGELOG.md:1-10`
+
+**Step 1: Add version entry**
+
+Insert a new version section at the top (after the header, before `## [1.8.0]`):
+
+```markdown
+## [1.9.0] - 2026-02-20
+
+### Added
+- **CHANGELOG generation step** — new inline lifecycle step that auto-generates a Keep a Changelog entry from the feature branch's git commits. Parses conventional commit prefixes (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`), categorizes entries, and presents for user approval before writing to `CHANGELOG.md`. Falls back to a single "Changes" section for non-conventional commits. Supports version detection from `package.json`, `Cargo.toml`, `pyproject.toml`, `mix.exs`, and git tags. Merges into existing `[Unreleased]` sections without overwriting.
+- Step added to Small enhancement (step 12), Feature (step 13), and Major feature (step 14) lifecycles. Quick fix is unchanged.
+```
+
+**Acceptance Criteria:**
+- [ ] CHANGELOG.md has a `## [1.9.0]` section before `## [1.8.0]`
+- [ ] The section has an `### Added` category
+- [ ] The entry describes the CHANGELOG generation step feature
+- [ ] The entry mentions conventional commit prefixes, user approval, version detection, and merge behavior
+
+---
+
+### Task 7: Commit
+
+**Step 1: Stage and commit all changes**
+
+```bash
+git add skills/start-feature/SKILL.md README.md CHANGELOG.md docs/plans/2026-02-20-changelog-generation.md docs/plans/2026-02-20-changelog-generation-plan.md
+git commit -m "feat: add CHANGELOG generation step to lifecycle (#8)"
+```
+
+**Acceptance Criteria:**
+- [ ] All five files are committed: `skills/start-feature/SKILL.md`, `README.md`, `CHANGELOG.md`, `docs/plans/2026-02-20-changelog-generation.md`, `docs/plans/2026-02-20-changelog-generation-plan.md`
+- [ ] Commit message references issue #8

--- a/docs/plans/2026-02-20-changelog-generation.md
+++ b/docs/plans/2026-02-20-changelog-generation.md
@@ -1,0 +1,202 @@
+# CHANGELOG Generation from Commits — Design Document
+
+**Date:** 2026-02-20
+**Status:** Draft
+**Issue:** #8
+
+## Overview
+
+The spec-driven lifecycle's final steps (Commit and PR) create commits and a pull request but do not update the CHANGELOG. This means every feature ships without a changelog entry unless the developer writes one manually. This enhancement adds a new inline step — "Generate CHANGELOG entry" — that parses the feature branch's git commits, categorizes them by conventional commit prefix, generates a Keep a Changelog entry, and presents it for user approval before writing it to `CHANGELOG.md`.
+
+## Example
+
+**Input** — commits on the feature branch:
+
+```
+feat: add CSV export to results page
+feat: add column selection dialog for CSV export
+fix: handle empty result set in CSV export
+refactor: extract export utilities from results component
+test: add CSV export integration tests
+```
+
+**Generated CHANGELOG entry:**
+
+```markdown
+## [Unreleased]
+
+### Added
+- Add CSV export to results page
+- Add column selection dialog for CSV export
+
+### Fixed
+- Handle empty result set in CSV export
+
+### Changed
+- Extract export utilities from results component
+
+### Testing
+- Add CSV export integration tests
+```
+
+**Non-conventional fallback** — when commits don't use prefixes:
+
+```
+Added CSV export feature
+Fixed empty result handling
+Updated tests
+```
+
+Generates:
+
+```markdown
+## [Unreleased]
+
+### Changes
+- Added CSV export feature
+- Fixed empty result handling
+- Updated tests
+```
+
+## User Flow
+
+### Step 1 — Collect and categorize commits
+The step runs `git log --format="%s" main...HEAD` to get all commit messages on the feature branch. Merge commits (`Merge branch...`, `Merge pull request...`) and fixup commits (`fixup!`, `squash!`) are filtered out. Each remaining commit is categorized by its conventional commit prefix.
+
+### Step 2 — Generate entry
+A CHANGELOG entry is generated in Keep a Changelog format. The version heading defaults to `## [Unreleased]`. If a version can be detected from `package.json` `version` field, `Cargo.toml` `[package] version`, `pyproject.toml` `[project] version`, `mix.exs` `@version`, or the latest semver git tag, it is offered as an alternative via `AskUserQuestion`.
+
+### Step 3 — Present for approval
+The generated entry is presented to the user via `AskUserQuestion` with options: "Looks good — write it", "Let me edit", "Skip CHANGELOG". If the user chooses to edit, they provide corrections in freeform text and the entry is revised. If they skip, the step announces the risk and proceeds.
+
+### Step 4 — Write to CHANGELOG.md
+The approved entry is written to the project's `CHANGELOG.md`:
+- **File exists with `[Unreleased]` section:** Merge new entries into existing categories. New categories are appended after existing ones.
+- **File exists without `[Unreleased]`:** Insert a new `## [Unreleased]` section after the file's header (first `# ` heading).
+- **No file exists:** Create `CHANGELOG.md` with the Keep a Changelog header and the generated entry.
+
+## Pipeline Architecture
+
+The CHANGELOG generation step is a standalone inline step inserted into the lifecycle after Code Review and before Final Verification. It runs for all scopes except Quick fix.
+
+**Current flow:**
+```
+... → Self-review → Code review → Final verification → Commit and PR
+```
+
+**New flow:**
+```
+... → Self-review → Code review → Generate CHANGELOG entry → Final verification → Commit and PR
+```
+
+### Step List Changes
+
+**Small enhancement** (was 13 steps, now 14):
+```
+- [ ] 12. Generate CHANGELOG entry      ← NEW
+- [ ] 13. Final verification             (was 12)
+- [ ] 14. Commit and PR                  (was 13)
+```
+
+**Feature** (was 14 steps, now 15):
+```
+- [ ] 13. Generate CHANGELOG entry      ← NEW
+- [ ] 14. Final verification             (was 13)
+- [ ] 15. Commit and PR                  (was 14)
+```
+
+**Major feature** (was 15 steps, now 16):
+```
+- [ ] 14. Generate CHANGELOG entry      ← NEW
+- [ ] 15. Final verification             (was 14)
+- [ ] 16. Commit and PR                  (was 15)
+```
+
+**Quick fix** (unchanged — no CHANGELOG step).
+
+### Skill Mapping Table Addition
+
+| Step | Skill to Invoke | Expected Output |
+|------|----------------|-----------------|
+| Generate CHANGELOG entry | No skill — inline step (see below) | CHANGELOG.md updated with categorized entry |
+
+### Commit Categorization Rules
+
+| Prefix | Keep a Changelog Category |
+|--------|--------------------------|
+| `feat:` | Added |
+| `fix:` | Fixed |
+| `refactor:` | Changed |
+| `docs:` | Documentation |
+| `test:` | Testing |
+| `chore:` | Maintenance |
+| No prefix match | Changes (fallback) |
+
+**Processing rules:**
+1. Strip the prefix and optional scope from commit messages: `feat(csv): add export` → `Add export`
+2. Capitalize the first letter of each entry
+3. Deduplicate entries with identical messages (keep one)
+4. Filter out merge commits matching `^Merge (branch|pull request)`
+5. Filter out fixup/squash commits matching `^(fixup|squash)!`
+6. Empty categories are omitted from the output
+
+### Version Detection
+
+Check these sources in order, use the first one found:
+
+1. `package.json` → `version` field
+2. `Cargo.toml` → `[package]` section `version` field
+3. `pyproject.toml` → `[project]` section `version` field
+4. `mix.exs` → `@version` attribute
+5. Latest git tag matching semver pattern (`v?[0-9]+\.[0-9]+\.[0-9]+`)
+
+If a version is detected, present it alongside `[Unreleased]` via `AskUserQuestion`. Default selection is `[Unreleased]`.
+
+### Merge Into Existing `[Unreleased]`
+
+When CHANGELOG.md already has an `[Unreleased]` section with entries:
+
+1. Parse existing categories under `[Unreleased]` (e.g., existing `### Added` with entries)
+2. For each generated category:
+   - If the category already exists, append new entries at the end of that category's list
+   - If the category doesn't exist, add it after the last existing category
+3. Preserve all existing entries — never remove or reorder them
+4. Deduplicate: if a generated entry matches an existing entry (case-insensitive), skip it
+
+## Changes to Existing Files
+
+### `skills/start-feature/SKILL.md`
+
+1. **Step lists:** Add "Generate CHANGELOG entry" step to Small enhancement, Feature, and Major feature step lists (after Code review, before Final verification). Renumber subsequent steps.
+2. **Skill mapping table:** Add the Generate CHANGELOG entry row.
+3. **New inline section:** Add "Generate CHANGELOG Entry Step (inline — no separate skill)" section after the Code Review Pipeline Step section, containing the full generation logic.
+
+### `README.md`
+
+1. **Lifecycle table:** Add the Generate CHANGELOG entry row showing it's an inline step.
+2. **Changelog section (if applicable):** Update with the new version entry for this feature.
+
+### `CHANGELOG.md`
+
+1. Add entry for this feature under the appropriate version.
+
+## Scope
+
+**Included:**
+- Inline CHANGELOG generation step in `skills/start-feature/SKILL.md`
+- Conventional commit prefix categorization with fallback
+- Keep a Changelog format generation
+- User approval flow (approve, edit, or skip)
+- Merge into existing `[Unreleased]` section
+- Version detection from common project files and git tags
+- New CHANGELOG.md creation when file doesn't exist
+- Step list and skill mapping table updates for all applicable scopes
+- README lifecycle table update
+
+**Excluded:**
+- Automatic version bumping (version detection is read-only, for suggestion only)
+- Modifying the `finishing-a-development-branch` superpowers skill
+- Supporting non-Keep-a-Changelog formats (e.g., GNU Changelog, custom formats)
+- Persisting generated entries across sessions if user skips
+- Breaking changes detection or `BREAKING CHANGE:` footer parsing (can be added later)
+- Scope parsing from conventional commits (e.g., `feat(auth):`) — scope is stripped, not used for grouping


### PR DESCRIPTION
## Summary
- Adds a new **Generate CHANGELOG entry** inline step to the start-feature lifecycle, positioned after Code Review and before Final Verification
- Parses feature branch commits, categorizes by conventional commit prefix (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`), generates a Keep a Changelog entry, and presents for user approval before writing
- Applies to Small Enhancement, Feature, and Major Feature scopes (Quick Fix excluded)

## Changes
- `skills/start-feature/SKILL.md` — Updated 3 step lists (renumbered), added skill mapping table row, added full inline section (Phase 1-6: collect, categorize, detect version, generate, approve, write)
- `README.md` — Added lifecycle table row, updated lifecycle diagram (renumbered steps 15-18)
- `CHANGELOG.md` — Added [1.9.0] entry with Added and Changed sections
- `docs/plans/` — Design document and implementation plan

## Key Design Decisions
- **[Unreleased] by default** — version detected from package.json/Cargo.toml/pyproject.toml/mix.exs/git tags offered as alternative
- **Merge into existing [Unreleased]** — appends to existing categories, never replaces
- **User approval required** — approve, edit, or skip with risk warning
- **Non-conventional fallback** — commits without prefixes grouped under "Changes"

## Test Plan
- [x] All 26 acceptance criteria verified by task-verifier agent
- [x] Code review passed (1 finding fixed: added Changed section to CHANGELOG)
- [x] Step lists correctly renumbered across all 3 scopes
- [x] Inline section follows Code Review Pipeline Step pattern

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)