### PR TITLE
fix: prevent verify-acceptance-criteria from over-triggering

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -87,7 +87,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "You are a gate-check that outputs ONLY a single word or a single BLOCK line. No other text.\n\nCheck the conversation for BOTH conditions:\nA) The assistant used Edit/Write tools to implement code from a plan that has acceptance criteria (- [ ] items)\nB) The verify-acceptance-criteria skill was NOT invoked\n\nIf BOTH A and B are true, output exactly:\nBLOCK: Run verify-acceptance-criteria before ending this session.\n\nOtherwise output exactly:\npass",
+            "prompt": "You are a gate-check that outputs ONLY a single word or a single BLOCK line. No other text.\n\nCheck the conversation for ALL conditions:\nA) The assistant used Edit/Write tools to implement code from a plan that has acceptance criteria (- [ ] items)\nB) The verify-acceptance-criteria skill was NOT invoked\nC) No PR was created during this session (no `gh pr create` or `gh pr view` showing an existing PR for the current branch)\n\nIf A AND B AND C are all true, output exactly:\nBLOCK: Run verify-acceptance-criteria before ending this session.\n\nOtherwise output exactly:\npass",
             "model": "claude-haiku-4-5-20251001",
             "timeout": 60,
             "statusMessage": "Checking acceptance criteria verification..."

--- a/skills/verify-acceptance-criteria/SKILL.md
+++ b/skills/verify-acceptance-criteria/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: verify-acceptance-criteria
-description: Run before claiming work is complete to mechanically verify all acceptance criteria from the implementation plan against the codebase. Delegates to task-verifier agent. Use after implementing tasks, before committing or creating PRs.
+description: >-
+  Use when asked to "verify acceptance criteria", "check criteria", or
+  "verify the implementation against the plan" during active feature
+  development. Do NOT trigger for issue management (close issue, comment),
+  worktree cleanup, or post-merge/post-PR operations.
 tools: Read, Glob, Grep, Task
 ---
 
@@ -17,6 +21,18 @@ Mechanically checks all acceptance criteria from an implementation plan against 
 - Before committing or creating a PR
 
 ## Process
+
+### Step 0: Check for Existing PR
+
+Before doing any work, check if a PR already exists for the current branch:
+
+```bash
+gh pr view --json url,state 2>/dev/null
+```
+
+**If a PR exists:** Announce "A PR already exists for this branch. Verification runs before PR creation in the standard workflow. Skipping." Exit gracefully — do not launch the task-verifier agent.
+
+**If no PR exists:** Continue with Step 1.
 
 ### Step 1: Find the Plan File
 


### PR DESCRIPTION
## Summary
- Narrowed skill description with explicit trigger keywords (`"verify acceptance criteria"`, `"check criteria"`) and negative scope (excludes issue management, worktree cleanup, post-merge/post-PR operations)
- Added PR-exists early-exit guard (Step 0) that checks `gh pr view` before launching the task-verifier agent — skips gracefully if a PR already exists
- Updated Stop hook prompt to require a third condition: no PR exists for the current branch before blocking session end

## Test plan
- [ ] Verify that saying "close this issue" no longer triggers verify-acceptance-criteria
- [ ] Verify that "cleanup the worktree" no longer triggers it
- [ ] Verify that on a branch with an existing PR, the skill exits early with the skip message
- [ ] Verify that the Stop hook passes (does not block) when a PR exists for the current branch
- [ ] Verify that normal verification flow still works during active development (no PR exists)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)