### PR TITLE
fix: use test -d instead of ls -d for worktree directory detection

### DIFF
--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -446,7 +446,13 @@ When YOLO mode is active and invoking `superpowers:using-git-worktrees`:
 **CRITICAL OVERRIDE — the using-git-worktrees skill may ask "Where should I create worktrees?" and may ask "proceed or investigate?" if baseline tests fail — you MUST SUPPRESS both prompts. Do NOT follow the skill's instructions to ask the user.**
 
 Instead:
-1. **Worktree directory:** Auto-select `.worktrees/` (project-local, hidden). If it doesn't exist, create it. Announce: `YOLO: using-git-worktrees — Worktree directory → .worktrees/ (auto-selected)`
+1. **Worktree directory:** Auto-select `.worktrees/` (project-local, hidden).
+   Check existence with:
+   ```bash
+   test -d .worktrees && echo "exists" || echo "creating"
+   ```
+   If it doesn't exist, create it. Do NOT use `ls -d` for existence checks — it returns non-zero when the directory doesn't exist, causing false tool errors.
+   Announce: `YOLO: using-git-worktrees — Worktree directory → .worktrees/ (auto-selected)`
 2. **Baseline test failure:** If tests fail during baseline verification, log the failures as a warning and proceed. Announce: `YOLO: using-git-worktrees — Baseline tests failed → Proceeding with warning (N failures logged)`. Do NOT ask the user whether to proceed or investigate — the lifecycle will catch test issues during implementation and verification steps.
 
 ### Finishing a Development Branch YOLO Override


### PR DESCRIPTION
## Summary
- Replaces fragile `ls -d` command with idiomatic `test -d` in the YOLO worktree override section of `start-feature`
- Adds explicit command template so the LLM uses it verbatim instead of generating one on-the-fly
- Adds warning against using `ls -d` for existence checks

Closes #38

## Test plan
- [ ] Run `start feature` in YOLO mode on a project without `.worktrees/` directory — verify `test -d` is used and no false tool errors occur
- [ ] Run `start feature` in YOLO mode on a project with existing `.worktrees/` directory — verify detection succeeds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)