### PR TITLE
Fix worktree directory check false exit code

### DIFF
--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -378,7 +378,7 @@ For inline steps (CHANGELOG generation, self-review, code review, study existing
 | Implementation plan | `superpowers:writing-plans` | Numbered tasks with acceptance criteria. **Override:** After the plan is saved, always proceed with subagent-driven execution — do not present the execution choice to the user. Immediately invoke `superpowers:subagent-driven-development`. |
 | Verify plan criteria | `feature-flow:verify-plan-criteria` | All tasks have verifiable criteria |
 | Commit planning artifacts | No skill — inline step (see below) | Planning docs and config committed to base branch |
-| Worktree setup | `superpowers:using-git-worktrees` | Isolated worktree created |
+| Worktree setup | `superpowers:using-git-worktrees` | Isolated worktree created. **Override:** When checking for existing worktree directories, use `test -d` instead of `ls -d` — the `ls -d` command returns a non-zero exit code when the directory doesn't exist, causing false Bash tool errors. Example: `test -d .worktrees && echo "exists" \|\| echo "not found"`. |
 | Copy env files | No skill — inline step (see below) | Env files available in worktree |
 | Implement | `superpowers:subagent-driven-development` | Code written with tests, spec-reviewed, and quality-reviewed per task |
 | Self-review | No skill — inline step (see below) | Code verified against coding standards before formal review |


### PR DESCRIPTION
## Summary
- Adds universal override to skill mapping table instructing `test -d` instead of `ls -d` for worktree directory existence checks
- Fix applies to all run modes (YOLO, Express, Interactive) — previously only YOLO/Express had the workaround
- `ls -d` returns non-zero when directory doesn't exist, causing false Bash tool errors

Related: #60

## Test plan
- [ ] Verify `test -d .worktrees && echo "exists" || echo "not found"` works correctly in both cases (directory exists / doesn't exist)
- [ ] Verify the override is picked up in Interactive mode lifecycle runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)