### PR TITLE
Fix session-report pricing table for Claude 4.6/4.5 models

### DIFF
--- a/skills/session-report/scripts/analyze-session.py
+++ b/skills/session-report/scripts/analyze-session.py
@@ -26,14 +26,48 @@ _START_SKILL_RE = re.compile(r"\bstart:\s", re.IGNORECASE)
 # =========================================================================
 # PRICING TABLE (USD per 1M tokens) — update when Anthropic changes pricing
 # =========================================================================
-# Source: https://docs.anthropic.com/en/docs/about-claude/models
+# Source: https://platform.claude.com/docs/en/about-claude/pricing
 # Format: model_substring -> {input, output, cache_read, cache_creation}
+# IMPORTANT: More specific keys must come BEFORE generic ones (e.g., "opus-4-6"
+# before "opus-4") because get_pricing() returns the first substring match.
 MODEL_PRICING = {
+    # Claude 4.6 (latest — reduced pricing vs 4.0/4.1)
+    "opus-4-6": {
+        "input": 5.00,
+        "output": 25.00,
+        "cache_read": 0.50,       # 10% of input
+        "cache_creation": 6.25,   # 125% of input (5m TTL)
+    },
+    "opus-4-5": {
+        "input": 5.00,
+        "output": 25.00,
+        "cache_read": 0.50,
+        "cache_creation": 6.25,
+    },
+    "sonnet-4-6": {
+        "input": 3.00,
+        "output": 15.00,
+        "cache_read": 0.30,
+        "cache_creation": 3.75,
+    },
+    "sonnet-4-5": {
+        "input": 3.00,
+        "output": 15.00,
+        "cache_read": 0.30,
+        "cache_creation": 3.75,
+    },
+    "haiku-4-5": {
+        "input": 1.00,
+        "output": 5.00,
+        "cache_read": 0.10,
+        "cache_creation": 1.25,
+    },
+    # Claude 4.0/4.1 (higher pricing tier)
     "opus-4": {
         "input": 15.00,
         "output": 75.00,
-        "cache_read": 1.50,       # 10% of input
-        "cache_creation": 18.75,  # 125% of input
+        "cache_read": 1.50,
+        "cache_creation": 18.75,
     },
     "sonnet-4": {
         "input": 3.00,


### PR DESCRIPTION
## Summary
The session-report pricing table used Opus 4.0/4.1 rates ($15/$75 per MTok) for all Opus 4.x models via substring matching. Opus 4.6 and 4.5 are priced at $5/$25 per MTok — **3x cheaper**. This caused all session cost reports to be inflated by ~3x.

**Before:** Session `d07f7109` reported $67.03 total cost
**After:** Same session correctly reports $22.40 total cost

## Root Cause
`get_pricing()` does substring matching: `"opus-4"` matched `"claude-opus-4-6"` and returned the $15/$75 Opus 4.0 rates. The fix adds specific entries (`opus-4-6`, `opus-4-5`, etc.) before the generic fallbacks so the first match is correct.

## Changes
- Add `opus-4-6`, `opus-4-5`, `sonnet-4-6`, `sonnet-4-5`, `haiku-4-5` entries with correct pricing
- Order matters: specific entries before generic ones (first substring match wins)
- Updated source URL to `platform.claude.com`
- Also applied to plugin cache copy for immediate effect

## Test plan
- [x] Re-ran analysis on session `d07f7109`: cost dropped from $67.03 → $22.40 (correct)
- [x] Opus 4.6 cache reads at $0.50/MTok (was $1.50)
- [x] Opus 4.6 output at $25/MTok (was $75)
- [x] Generic `opus-4` fallback still works for Opus 4.0/4.1 sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)