### PR TITLE
Sync base branch with remote before worktree + merge-first strategy

### DIFF
--- a/dispatcher/execute.py
+++ b/dispatcher/execute.py
@@ -20,9 +20,16 @@ def create_branch(issue_number: int, scope: str, config: Config) -> str:
     slug = _slugify(f"issue-{issue_number}")
     branch_name = f"{prefix}/{issue_number}-{slug}"
 
+    # Sync with remote before branching to prevent stale-base conflicts
+    subprocess.run(
+        ["git", "fetch", "origin"],
+        capture_output=True, text=True, timeout=30,
+    )
+    start_point = f"origin/{config.base_branch}"
+
     try:
         subprocess.run(
-            ["git", "checkout", "-b", branch_name, config.base_branch],
+            ["git", "checkout", "-b", branch_name, start_point],
             capture_output=True, text=True, timeout=30, check=True,
         )
     except subprocess.CalledProcessError:

--- a/references/git-workflow.md
+++ b/references/git-workflow.md
@@ -53,6 +53,18 @@ git show HEAD                  # reveals which criterion introduced the regressi
 git bisect reset
 ```
 
+## Integration Strategy: Merge-First
+
+Feature-flow defaults to `git merge` (not `git rebase`) when syncing feature branches with the base branch before PR creation. This is configurable via `git_strategy` in `.feature-flow.yml`.
+
+**Why merge over rebase:**
+- `git rebase` replays each commit individually — N commits can produce N separate conflict rounds
+- `git merge` resolves everything in a single pass — one conflict resolution at most
+- Feature-flow context files (`.feature-flow/*`, `FEATURE_CONTEXT.md`, `CHANGELOG.md`) change on every feature branch, making them guaranteed conflict targets during rebase
+- Most PRs are squash-merged, so the linear history benefit of rebase is moot
+
+**When to use rebase:** Only when the project enforces linear history and does not use squash-merge. Set `git_strategy: rebase` in `.feature-flow.yml`.
+
 ## Examples
 
 **Single criterion (short):**

--- a/references/project-context-schema.md
+++ b/references/project-context-schema.md
@@ -24,6 +24,7 @@ gotchas:
   - "WhoisFreaks bulk endpoint has separate RPM bucket from single-domain"
 types_path: src/types/database.types.ts  # Optional: canonical generated types path
 default_branch: staging  # Optional: PR target branch (default: detected via cascade)
+git_strategy: merge      # Optional: merge (default) | rebase — integration strategy for syncing with base branch
 notifications:          # Optional: notification preference written by start skill
   on_stop: bell         # bell | desktop | none
 knowledge_base:         # Optional: per-feature context file settings
@@ -167,6 +168,25 @@ default_branch: staging
 ```
 
 **When needed:** Only when the automatic detection cascade doesn't select the correct branch. Most projects using `main` as their PR target don't need this field.
+
+### `git_strategy`
+
+Optional integration strategy for the "Sync with Base Branch" lifecycle step. Controls whether `git merge` or `git rebase` is used to integrate base branch changes before PR creation.
+
+| Value | Behavior |
+|-------|----------|
+| `merge` (default) | `git merge origin/<base-branch> --no-edit` — single conflict resolution pass regardless of commit count |
+| `rebase` | `git rebase origin/<base-branch>` — replays each commit individually (linear history, but N commits = up to N conflict rounds) |
+
+**When to use `rebase`:** Only when the project enforces linear history and does not use squash-merge for PRs. Most projects should use the default `merge`.
+
+**Format:** Single string value.
+
+```yaml
+git_strategy: merge  # merge (default) | rebase
+```
+
+**When absent:** Defaults to `merge`. The field is never auto-written; add it manually only if you need `rebase`.
 
 ### `notifications`
 

--- a/skills/start/references/inline-steps.md
+++ b/skills/start/references/inline-steps.md
@@ -361,7 +361,9 @@ After writing, announce: "CHANGELOG.md updated with N entries across M categorie
 
 ## Sync with Base Branch Step
 
-This step runs after final verification and before commit and PR. It fetches the latest from origin and rebases the feature branch onto the base branch, ensuring no divergence has accumulated from parallel feature work. CHANGELOG.md conflicts — the most common parallel-branch conflict — are resolved automatically by combining both sets of Unreleased entries.
+This step runs after final verification and before commit and PR. It fetches the latest from origin and merges the base branch into the feature branch, ensuring no divergence has accumulated from parallel feature work. Uses `git merge` instead of `git rebase` — merge produces a single conflict resolution pass regardless of commit count, while rebase replays each commit individually (N commits = up to N separate conflict rounds). This is especially important for feature-flow branches that touch context tracking files (`.feature-flow/*`, `FEATURE_CONTEXT.md`, `CHANGELOG.md`), which are guaranteed conflict targets.
+
+**Configuration:** The merge strategy is the default. Projects requiring linear history can set `git_strategy: rebase` in `.feature-flow.yml` to use the old rebase behavior.
 
 **Process:**
 
@@ -374,15 +376,19 @@ This step runs after final verification and before commit and PR. It fetches the
    ```bash
    git rev-list HEAD..origin/<base-branch> --count
    ```
-   - If output is `0`: announce "Base branch is up to date — no rebase needed." Skip to step 5.
+   - If output is `0`: announce "Base branch is up to date — no merge needed." Skip to step 5.
    - If output is non-zero: proceed to step 3.
 
-3. Attempt rebase:
+3. Read `git_strategy` from `.feature-flow.yml` (default: `merge`). Then integrate:
    ```bash
+   # Default (merge):
+   git merge origin/<base-branch> --no-edit
+
+   # If git_strategy: rebase:
    git rebase origin/<base-branch>
    ```
 
-4. If rebase exits with conflicts:
+4. If merge/rebase exits with conflicts:
    a. Identify conflicted files:
       ```bash
       git diff --name-only --diff-filter=U
@@ -400,19 +406,17 @@ This step runs after final verification and before commit and PR. It fetches the
         ```
         1. Resolve conflicts in: [file list]
         2. Stage resolved files: git add <file>
-        3. Continue rebase: git rebase --continue
+        3. Complete: git commit (for merge) or git rebase --continue (for rebase)
         4. Type 'continue' to resume the lifecycle
         ```
       - Wait for the user to resolve and respond before proceeding.
    d. If only CHANGELOG.md was conflicted (now auto-resolved and staged):
-      ```bash
-      git rebase --continue
-      ```
-      If `git rebase --continue` itself triggers another CHANGELOG conflict (multiple commits touched it), repeat step 4b until the rebase completes.
+      - For merge: `git commit --no-edit` (completes the merge commit)
+      - For rebase: `git rebase --continue` (may trigger further conflicts on subsequent commits — repeat step 4b)
 
 5. Announce: "Synced with origin/<base-branch>. Ready to push and create PR."
 
-**YOLO behavior:** Run silently. If non-CHANGELOG conflicts are detected, pause and announce the conflict files — YOLO cannot resolve arbitrary conflicts automatically. Announce: `YOLO: start — Sync with base branch → [up to date | rebased N commits | conflicts in: files (paused)]`
+**YOLO behavior:** Run silently. If non-CHANGELOG conflicts are detected, pause and announce the conflict files — YOLO cannot resolve arbitrary conflicts automatically. Announce: `YOLO: start — Sync with base branch → [up to date | merged N commits | conflicts in: files (paused)]`
 
 ---
 

--- a/skills/start/references/project-context.md
+++ b/skills/start/references/project-context.md
@@ -99,6 +99,44 @@ Announce: `"Detected base branch: [branch]. All PR targets and branch diffs will
 
 **YOLO behavior:** No prompt — always auto-detected. Announce: `YOLO: start — Base branch detection → [branch]`
 
+## Base Branch Sync
+
+After detecting the base branch, sync it with the remote to ensure the worktree is created from the latest state. This prevents stale-base conflicts during the end-of-lifecycle sync step.
+
+1. Fetch latest from origin:
+   ```bash
+   git fetch origin
+   ```
+
+2. Check if local base branch is behind remote:
+   ```bash
+   git rev-list <base_branch>..origin/<base_branch> --count
+   ```
+   - If `0`: announce "Base branch is up to date with origin." Skip to next section.
+   - If non-zero: proceed to step 3.
+
+3. Update local base branch to match remote:
+   ```bash
+   # If currently on the base branch:
+   git pull --ff-only origin/<base_branch>
+
+   # If on a different branch (can't pull):
+   git fetch origin <base_branch>:<base_branch>
+   ```
+   `git fetch origin <branch>:<branch>` does a fast-forward update of the local ref without checking it out. If the local branch has diverged (non-fast-forward), it will fail — see edge cases below.
+
+**Edge cases:**
+
+| Scenario | Behavior |
+|----------|----------|
+| Local base has uncommitted changes | Stash before sync (`git stash`), pop after (`git stash pop`) |
+| Local base has diverged (non-fast-forward) | Fetch will fail. Warn: "Local `<branch>` has diverged from `origin/<branch>` — cannot fast-forward. Proceeding with local state." |
+| Remote unreachable (offline) | `git fetch origin` fails. Announce: "Remote unreachable — proceeding with local base branch." Continue lifecycle. |
+
+**YOLO behavior:** Auto-sync silently. Announce: `YOLO: start — Base branch sync → fetched origin/<base_branch> (N commits ahead of local)` or `YOLO: start — Base branch sync → up to date`
+
+**Interactive/Express behavior:** Announce sync result. If local has diverged (non-fast-forward), warn the user and proceed with local state.
+
 ## Session Model Check
 
 After detecting the base branch, detect the current model and announce it. The orchestrator should run on Opus 4.6 for the full session (1M context, standard pricing). Cost optimization comes from subagent routing — Task dispatches use explicit `model` params to run subagents on Sonnet or Haiku. See `references/model-routing.md` for the full routing strategy.


### PR DESCRIPTION
## Summary
- Add early base branch sync in Step 0 to ensure worktrees are created from latest remote state
- Change end-of-lifecycle sync from `git rebase` to `git merge` as the default (configurable via `git_strategy` in `.feature-flow.yml`)
- Update dispatcher to use `origin/<base_branch>` as branch start point (not stale local ref)

## Evidence
Session `d07f7109` spent **13 minutes (42%)** resolving 5 rebase conflict rounds because the worktree was created from a stale local `staging` branch.

## Files changed
- `skills/start/references/project-context.md` — add "Base Branch Sync" section
- `skills/start/references/inline-steps.md` — change sync step from rebase to merge
- `references/project-context-schema.md` — add `git_strategy` field
- `references/git-workflow.md` — add merge-first strategy documentation
- `dispatcher/execute.py` — add `git fetch origin` + use `origin/<base_branch>` in `create_branch()`

## Test plan
- [x] 140 dispatcher tests passing
- [x] `create_branch()` now fetches origin and uses `origin/<base_branch>` as start point
- [x] `git_strategy` documented in schema with `merge` default and `rebase` opt-in
- [x] End-of-lifecycle sync reads `git_strategy` from config

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)