### PR TITLE
feat: PR review and comment triage with best-effort remediation (#226)

### DIFF
--- a/.changelogs/226-review-triage.md
+++ b/.changelogs/226-review-triage.md
@@ -1,0 +1,17 @@
+---
+date: 2026-04-08
+pr: TBD
+scope: feature-flow
+issue: 226
+---
+
+### Added
+
+- `merge-prs`: single-pass PR review triage that fetches inline review comments, discussion comments, and formal reviews; classifies each unresolved thread into one of 6 categories (blocker/suggestion/nit/question/praise/unclear); attempts best-effort remediation; and replies with fix commit attribution. Replaces the previous binary `CHANGES_REQUESTED` skip in `SKILL.md` Step 4a (#226).
+- `merge-prs`: new `references/review-triage.md` specialization file mirroring `ci-remediation.md` structure. Documents the GraphQL `reviewThreads` fetch, four-stage thread filter (outdated, resolved, self-reply, addressed-by-later-approval), priority-ordered classification heuristics, per-category fix strategies, commit grouping by `(reviewer, file)`, reply templates, and mode-aware escalation.
+- `.feature-flow.yml`: new optional `merge.wait_for_rereview` config field (default `false`) for opting into reviewer re-approval polling after auto-fixes.
+
+### Changed
+
+- `merge-prs`: review triage runs **before** CI remediation in Step 4a so that any fix commits trigger a fresh CI run that `ci-remediation.md` can then handle.
+- `skills/merge-prs/references/best-effort-remediation.md`: marked review triage as a current consumer of the shared bounded-attempt pattern (previously listed as "future").

--- a/.feature-flow.yml
+++ b/.feature-flow.yml
@@ -27,6 +27,7 @@ design_preferences:
 # require_ci: true             # require CI green before merge (default: true)
 # require_review: true         # require approved review before merge (default: true)
 # auto_discover: label         # label | body_marker | both (default: label)
+# wait_for_rereview: false     # Wait for re-approval after auto-fixing review comments (default: false; see skills/merge-prs/references/review-triage.md)
 # ci_remediation:                       # Bounded CI failure remediation loop (see skills/merge-prs/references/ci-remediation.md)
 #   max_attempts: 3                     # integer >= 1 (default: 3)
 #   max_wall_clock_minutes: 10          # integer >= 1 (default: 10)

--- a/docs/plans/2026-04-08-graduated-conflict-resolution-plan.md
+++ b/docs/plans/2026-04-08-graduated-conflict-resolution-plan.md
@@ -1,0 +1,490 @@
+# Graduated Merge Conflict Resolution — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Implement the 4-tier merge conflict resolution ladder (Tier 1 auto / Tier 2 test-verified / Tier 3 diff-presentation / Tier 4 skip) by updating `skills/merge-prs/references/conflict-resolution.md` and `skills/merge-prs/SKILL.md` to match the design document.
+
+**Architecture:** This is a **documentation-only change**. Feature-flow is a Markdown skill plugin — there is no runtime code. "Implementation" means adding/editing specific sections, tables, examples, and rules in two Markdown files. Verification is grep-based (content-exists assertions) because the "code under test" is prose that downstream Claude sessions will read and follow.
+
+**Tech Stack:** Markdown (CommonMark + GitHub Flavored Markdown). Bash `grep` / `wc` / `test` for machine verification. No new runtime dependencies.
+
+**Design doc:** [`docs/plans/2026-04-08-graduated-conflict-resolution.md`](2026-04-08-graduated-conflict-resolution.md)
+
+**Issue:** #225
+
+**Files touched:**
+- `skills/merge-prs/references/conflict-resolution.md` (extend)
+- `skills/merge-prs/SKILL.md` (extend)
+
+---
+
+## Task Breakdown
+
+Tasks are ordered so that each produces a self-contained commit that a reviewer can read independently. Later tasks depend on earlier ones (e.g., Task 6 adds an Example that references Tier 2, so Task 1 must land first).
+
+---
+
+### Task 1: Add Tier 2 (attempt-with-test-verification) section to conflict-resolution.md
+
+**Files:**
+- Modify: `skills/merge-prs/references/conflict-resolution.md` (insert new section after the existing "Behavioral Conflicts" section, before the "Design Doc Context Loading" section at line 88)
+
+**Step 1: Add the Tier 2 section**
+
+Insert a new `## Tier 2: Attempt-with-Test-Verification (NEW)` section containing:
+- A short "When this applies" paragraph explaining Tier 2 targets cases the behavioral keyword check would currently flag, but where an additive union merge is mechanically safe (quoting the design doc's Step 2 language).
+- A numbered procedure: (1) attempt additive merge, (2) discover test runner, (3) run tests with hard timeout, (4) commit + push on green OR (5) discard via `git checkout -- .` and fall through to Tier 3 on red.
+- A "Commit message contract" sub-bullet specifying the exact format: `merge: resolve conflict, verified by tests`
+- A "Mode Behavior" 3-column table (YOLO | Express | Interactive) matching the design doc's Mode Behavior table rows for Tier 2.
+- An announcement template block showing the Tier 2 attempt / success / failure formats from the design doc.
+
+**Step 2: Verify the section was added**
+
+Run:
+```bash
+grep -c '^## Tier 2' skills/merge-prs/references/conflict-resolution.md
+grep -q 'merge: resolve conflict, verified by tests' skills/merge-prs/references/conflict-resolution.md
+grep -q 'git checkout -- \.' skills/merge-prs/references/conflict-resolution.md
+grep -q 'additive union merge\|additive merge' skills/merge-prs/references/conflict-resolution.md
+```
+Expected: first count >= 1; all three `grep -q` commands exit 0.
+
+**Step 3: Commit**
+
+```bash
+git add skills/merge-prs/references/conflict-resolution.md
+git commit -m "docs(merge-prs): add Tier 2 attempt-with-test-verification to conflict-resolution.md"
+```
+
+**Acceptance Criteria:**
+- [ ] Tier 2 H2 section header exists in conflict-resolution.md measured by at least one H2 match verified by `test $(grep -c '^## Tier 2' skills/merge-prs/references/conflict-resolution.md) -ge 1`
+- [ ] Commit message contract literal present measured by exact string match verified by `grep -q 'merge: resolve conflict, verified by tests' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Discard instruction present measured by literal checkout match verified by `grep -q 'git checkout -- \.' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Additive merge concept documented measured by regex match verified by `grep -Eq 'additive (union )?merge' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Mode Behavior table present within Tier 2 section measured by YOLO token appearing within 30 lines after the Tier 2 heading verified by `grep -A 30 '^## Tier 2' skills/merge-prs/references/conflict-resolution.md | grep -q 'YOLO'`
+
+**Quality Constraints:**
+- Style: Markdown prose matches existing conflict-resolution.md conventions — H2 for tier sections, H3 for subsections, fenced code blocks with language hints, 3-column mode tables with `YOLO | Express | Interactive` headers
+- Terminology: Uses exact terms from the design doc — "additive merge", "structural independence gate", "safety invariant"
+- Cross-reference integrity: Does not embed SKILL.md line numbers (line-number-free prose only)
+- Pattern: Follow the existing "Trivial Conflicts" subsection structure as a template
+
+---
+
+### Task 2: Rename "Behavioral Conflicts" section to "Tier 3: Diff Presentation" and add Tier 3 content
+
+**Files:**
+- Modify: `skills/merge-prs/references/conflict-resolution.md:46-85` (the current "Behavioral Conflicts" section)
+
+**Step 1: Rename the section header**
+
+Change `### Behavioral Conflicts (require confirmation)` to `## Tier 3: Diff Presentation (Always Pauses)`. Promote from H3 to H2 so Tier 1/2/3/4 are sibling sections.
+
+**Step 2: Add the Tier 3-specific content**
+
+Within the section:
+- Add an opening paragraph: "Tier 3 always pauses via `AskUserQuestion`, regardless of mode. This is the safety invariant of the ladder."
+- Keep the existing "Never auto-resolve" sentence.
+- Keep the existing Type/Detection heuristic table (it still documents the patterns that trigger Tier 3).
+- Update the `AskUserQuestion` options list: add **"Accept proposed"** as the first option (takes the Tier 2 merge attempt if any), keeping the existing "Accept ours" / "Accept theirs" / "I'll resolve manually" / "Skip this PR" as options 2-5.
+- Add a "Presentation contents" sub-bullet: the raw conflict diff (trimmed to 40 lines), the Tier 2 proposed resolution (if any), and test failure output (if Tier 2 was attempted and failed).
+
+**Step 3: Verify the rename and content**
+
+Run:
+```bash
+! grep -q '^### Behavioral Conflicts' skills/merge-prs/references/conflict-resolution.md
+grep -q '^## Tier 3' skills/merge-prs/references/conflict-resolution.md
+grep -q 'Accept proposed' skills/merge-prs/references/conflict-resolution.md
+grep -q 'safety invariant' skills/merge-prs/references/conflict-resolution.md
+grep -q 'Always Pauses\|always pause' skills/merge-prs/references/conflict-resolution.md
+```
+Expected: all commands exit 0.
+
+**Step 4: Commit**
+
+```bash
+git add skills/merge-prs/references/conflict-resolution.md
+git commit -m "docs(merge-prs): rename Behavioral Conflicts to Tier 3 and add diff-presentation spec"
+```
+
+**Acceptance Criteria:**
+- [ ] Old "Behavioral Conflicts" H3 header removed measured by zero matches verified by `! grep -q '^### Behavioral Conflicts' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Tier 3 H2 section header exists measured by at least one H2 match verified by `grep -q '^## Tier 3' skills/merge-prs/references/conflict-resolution.md`
+- [ ] "Accept proposed" option present in Tier 3 options list measured by literal string match verified by `grep -q 'Accept proposed' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Safety invariant statement present measured by literal string match verified by `grep -q 'safety invariant' skills/merge-prs/references/conflict-resolution.md`
+- [ ] "Always pauses" pause-semantics documented measured by regex match verified by `grep -Eq 'Always Pauses|always pause' skills/merge-prs/references/conflict-resolution.md`
+
+**Quality Constraints:**
+- Style: Markdown prose matches existing conflict-resolution.md conventions — H2 for tier sections, 5-option `AskUserQuestion` lists as bulleted items
+- Terminology: Uses exact terms "safety invariant", "Always Pauses"; "Accept proposed" must appear as the FIRST option in the list (before "Accept ours")
+- Preservation: Existing behavioral detection heuristic table and "Design Doc Context Loading" section must remain intact and unrenamed
+- Pattern: Follow existing Tier 3 option-list structure from the current `AskUserQuestion` block in conflict-resolution.md
+
+---
+
+### Task 3: Add Test Runner Discovery subsection
+
+**Files:**
+- Modify: `skills/merge-prs/references/conflict-resolution.md` (add new subsection under Tier 2)
+
+**Step 1: Add the subsection**
+
+Add a `### Test Runner Discovery` subsection (H3, nested under Tier 2's H2) containing:
+- **Discovery order:** a numbered list — (1) explicit config `merge.conflict_resolution.test_command` in `.feature-flow.yml`, (2) stack-based detection for `node-js` (lockfile → `pnpm test` / `yarn test` / `npm test`), (3) stack-based detection for `python` (`pytest.ini`/`pyproject.toml`/`setup.cfg` → `pytest`), (4) no match → skip Tier 2 with reason `test-runner-not-found`.
+- A code block showing the exact bash detection for the node-js stack (ls-based lockfile check).
+- A note that `packageManager` field in `package.json` wins over lockfile heuristics if present.
+
+**Step 2: Verify**
+
+```bash
+grep -q '^### Test Runner Discovery' skills/merge-prs/references/conflict-resolution.md
+grep -q 'merge.conflict_resolution.test_command' skills/merge-prs/references/conflict-resolution.md
+grep -q 'pnpm-lock.yaml' skills/merge-prs/references/conflict-resolution.md
+grep -q 'pytest' skills/merge-prs/references/conflict-resolution.md
+grep -q 'test-runner-not-found' skills/merge-prs/references/conflict-resolution.md
+```
+Expected: all exit 0.
+
+**Step 3: Commit**
+
+```bash
+git add skills/merge-prs/references/conflict-resolution.md
+git commit -m "docs(merge-prs): add Test Runner Discovery subsection for Tier 2"
+```
+
+**Acceptance Criteria:**
+- [ ] Test Runner Discovery H3 subsection exists measured by header presence verified by `grep -q '^### Test Runner Discovery' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Explicit config key documented measured by literal string match verified by `grep -q 'merge.conflict_resolution.test_command' skills/merge-prs/references/conflict-resolution.md`
+- [ ] pnpm lockfile detection mentioned measured by literal match verified by `grep -q 'pnpm-lock.yaml' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Python pytest runner mentioned measured by literal match verified by `grep -q 'pytest' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Fallback reason documented measured by literal match verified by `grep -q 'test-runner-not-found' skills/merge-prs/references/conflict-resolution.md`
+
+**Quality Constraints:**
+- Style: H3 subsection under the Tier 2 H2, numbered discovery order list, fenced bash code block for the ls-based detection
+- Terminology: Uses exact config key `merge.conflict_resolution.test_command` and skip reason `test-runner-not-found` (no variants)
+- Cross-reference integrity: Config key naming matches the existing `merge.ci_remediation.*` pattern from ci-remediation.md
+- Pattern: Follow the numbered-list discovery pattern from the design doc § Test Runner Discovery section
+
+---
+
+### Task 4: Add Timeout Detection subsection
+
+**Files:**
+- Modify: `skills/merge-prs/references/conflict-resolution.md` (add new subsection under Tier 2, after Test Runner Discovery)
+
+**Step 1: Add the subsection**
+
+Add a `### Timeout Detection` subsection (H3) containing:
+- An explanation that macOS does not ship `timeout` by default.
+- A bash detection block (copied from the design doc) that tries `timeout` → `gtimeout` → bash-kill fallback.
+- The bash-kill fallback pattern with background-job + sleep + kill-TERM.
+- A note that the default timeout is 5 minutes, configurable via `merge.conflict_resolution.test_timeout_minutes` (minimum 1 minute).
+
+**Step 2: Verify**
+
+```bash
+grep -q '^### Timeout Detection' skills/merge-prs/references/conflict-resolution.md
+grep -q 'gtimeout' skills/merge-prs/references/conflict-resolution.md
+grep -q 'test_timeout_minutes' skills/merge-prs/references/conflict-resolution.md
+grep -q 'kill -TERM' skills/merge-prs/references/conflict-resolution.md
+```
+Expected: all exit 0.
+
+**Step 3: Commit**
+
+```bash
+git add skills/merge-prs/references/conflict-resolution.md
+git commit -m "docs(merge-prs): add Timeout Detection subsection with macOS fallback"
+```
+
+**Acceptance Criteria:**
+- [ ] Timeout Detection H3 subsection exists measured by header presence verified by `grep -q '^### Timeout Detection' skills/merge-prs/references/conflict-resolution.md`
+- [ ] macOS gtimeout alternative mentioned measured by literal match verified by `grep -q 'gtimeout' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Timeout config key documented measured by literal match verified by `grep -q 'test_timeout_minutes' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Bash kill fallback pattern present measured by literal signal match verified by `grep -q 'kill -TERM' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Default 5-minute timeout documented measured by regex match verified by `grep -Eq '5 minutes|default.*5' skills/merge-prs/references/conflict-resolution.md`
+
+**Quality Constraints:**
+- Style: H3 subsection under the Tier 2 H2, fenced bash code blocks for the detection and fallback patterns
+- Terminology: Config key `merge.conflict_resolution.test_timeout_minutes` (exact); minimum value 1 stated explicitly
+- Cross-reference integrity: Detection bash block must exactly match the design doc's Timeout Detection code block (byte-for-byte, including comments)
+- Pattern: Follow the shell-detection-then-fallback pattern; document both `command -v` detection and the background-kill fallback
+
+---
+
+### Task 5: Update Structure Classification to route to Tier 2
+
+**Files:**
+- Modify: `skills/merge-prs/references/conflict-resolution.md:26-85` (the Structure Classification pre-filter and behavioral keyword check)
+
+**Step 1: Update the Structure Classification routing**
+
+In the existing "Structure Classification (pre-filter)" section, update the "How to apply" numbered steps so that step 6 (currently "→ proceed to behavioral keyword check") routes to a new decision:
+
+After the behavioral keyword check matches, apply a **structural independence gate** (from the design doc Step 2). If the gate passes → Tier 2. If it does not pass → Tier 3. Add a short code/pseudocode block for the gate.
+
+Also update the classification table to list Tier 2 as the destination for "Both-sided modification (structurally independent)" and Tier 3 for "Both-sided modification (semantic overlap)".
+
+**Step 2: Update the behavioral keyword check text**
+
+The existing `Step 2: Keyword check` note should be expanded to say: "If keywords match, run the structural independence gate (defined in the Tier 2 section). Pass → Tier 2. Fail → Tier 3."
+
+**Step 3: Verify**
+
+```bash
+grep -q 'structural independence gate\|Structural Independence' skills/merge-prs/references/conflict-resolution.md
+grep -q 'semantic overlap' skills/merge-prs/references/conflict-resolution.md
+# The classification table should now reference Tier 2 and Tier 3:
+grep -Ec '\| (Tier [123]|TRIVIAL|trivial) ' skills/merge-prs/references/conflict-resolution.md
+```
+Expected: first two grep -q commands exit 0; third count >= 2 (at least Tier 2 and Tier 3 referenced in tables).
+
+**Step 4: Commit**
+
+```bash
+git add skills/merge-prs/references/conflict-resolution.md
+git commit -m "docs(merge-prs): route Structure Classification to Tier 2 via independence gate"
+```
+
+**Acceptance Criteria:**
+- [ ] Structural independence gate referenced in Structure Classification measured by regex match verified by `grep -Eq 'structural independence gate|Structural Independence' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Semantic overlap terminology used in routing decision measured by literal match verified by `grep -q 'semantic overlap' skills/merge-prs/references/conflict-resolution.md`
+- [ ] Tier 2 referenced at least 3 times (header + routing + cross-reference) measured by count verified by `test $(grep -c 'Tier 2' skills/merge-prs/references/conflict-resolution.md) -ge 3`
+- [ ] Tier 3 referenced at least 3 times (header + routing + cross-reference) measured by count verified by `test $(grep -c 'Tier 3' skills/merge-prs/references/conflict-resolution.md) -ge 3`
+- [ ] Existing Tier 1 rules (one-sided, adjacent additions, context-only) remain unchanged measured by literal match on preserved line verified by `grep -q 'one-sided modification' skills/merge-prs/references/conflict-resolution.md`
+
+**Quality Constraints:**
+- Style: Update the existing "How to apply" numbered list in-place; do not duplicate the step numbering
+- Terminology: Use "structural independence gate" (lowercase) as the canonical term; "semantic overlap" as the opposite
+- Preservation: Tier 1 rules (one-sided modification, adjacent additions, context-only keywords) must NOT be modified — only the "both-sided modification" routing changes
+- Pattern: Follow the existing step-by-step "Step 1: ... Step 2: ..." structure in the Behavioral Detection heuristic
+
+---
+
+### Task 6: Add Example 7 (Tier 2 success + escalation)
+
+**Files:**
+- Modify: `skills/merge-prs/references/conflict-resolution.md` (add new example at the end of the Examples section)
+
+**Step 1: Add Example 7**
+
+Add a `### Example 7: Structurally-independent both-sided modification — Tier 2` block containing:
+- A realistic conflict diff showing both sides adding different statements in the same function body (one side adds `rateLimit()`, the other adds `validatePassword()`), both with behavioral keywords nearby, but with non-overlapping semantic targets.
+- An "Old classification" line explaining why the behavioral keyword check would have flagged this as behavioral and paused.
+- A "New classification" line explaining routing to Tier 2, the additive merge, and the test verification step.
+- A "Tier 2 outcome" block showing both paths:
+  - **Tests pass:** commit with `merge: resolve conflict, verified by tests`, continue.
+  - **Tests fail:** discard via `git checkout -- .`, escalate to Tier 3 with test output captured.
+
+**Step 2: Verify**
+
+```bash
+grep -q '^### Example 7' skills/merge-prs/references/conflict-resolution.md
+# Count all examples — should be >= 7 now:
+grep -c '^### Example [0-9]' skills/merge-prs/references/conflict-resolution.md
+```
+Expected: first grep exits 0; count >= 7.
+
+**Step 3: Commit**
+
+```bash
+git add skills/merge-prs/references/conflict-resolution.md
+git commit -m "docs(merge-prs): add Example 7 for Tier 2 success and escalation"
+```
+
+**Acceptance Criteria:**
+- [ ] Example 7 H3 header exists measured by header presence verified by `grep -q '^### Example 7' skills/merge-prs/references/conflict-resolution.md`
+- [ ] At least 7 distinct numbered examples present measured by count of `### Example N` headers verified by `test $(grep -c '^### Example [0-9]' skills/merge-prs/references/conflict-resolution.md) -ge 7`
+- [ ] Example 7 documents the Tests-pass path measured by literal match within 40 lines after header verified by `grep -A 40 '^### Example 7' skills/merge-prs/references/conflict-resolution.md | grep -q 'Tests pass'`
+- [ ] Example 7 documents the Tests-fail escalation path measured by literal match within 40 lines verified by `grep -A 40 '^### Example 7' skills/merge-prs/references/conflict-resolution.md | grep -q 'escalate'`
+- [ ] Example 7 shows realistic conflict markers measured by presence of diff markers verified by `grep -A 40 '^### Example 7' skills/merge-prs/references/conflict-resolution.md | grep -q '<<<<<<<'`
+
+**Quality Constraints:**
+- Style: H3 header at the same level as Examples 1-6, fenced code block for the diff, "Old classification" and "New classification" labels matching Examples 4 and 5
+- Terminology: Uses "additive merge", "Tier 2", "Tier 3", matching the rest of the file
+- Preservation: Must not modify Examples 1-6
+- Pattern: Follow Example 4 (additive-only reclassification) and Example 5 (context-only keywords) as the structural template for the Old/New classification narrative
+
+---
+
+### Task 7: Update SKILL.md §Conflict Resolution summary to the 4-tier ladder
+
+**Files:**
+- Modify: `skills/merge-prs/SKILL.md:223-249` (the §Conflict Resolution section)
+
+**Step 1: Rewrite the summary section**
+
+Replace the current numbered summary (steps 1-7) with an updated version that describes the 4-tier ladder:
+1. Create the conflict worktree (unchanged).
+2. Merge base branch into the worktree (unchanged).
+3. For each conflict, classify via Structure Classification → route to Tier 1 / Tier 2 / Tier 3 / Tier 4.
+4. **Tier 1:** auto-resolve, announce.
+5. **Tier 2:** attempt additive merge, run tests with timeout, commit with `merge: resolve conflict, verified by tests` if green; otherwise discard and escalate to Tier 3.
+6. **Tier 3:** present diff + proposed resolution + test failure (if any), pause via `AskUserQuestion`. ALWAYS pauses, even in YOLO.
+7. **Tier 4:** skip PR with reason, continue with next PR.
+8. After resolution: existing `git add . && git commit && git push` flow.
+9. Cleanup worktree (unchanged — keep the existing CWD Safety Guard block verbatim).
+
+**Step 2: Verify the CWD Safety Guard is unchanged**
+
+```bash
+grep -q 'CWD Safety Guard' skills/merge-prs/SKILL.md
+grep -q 'ORIG_DIR=\$(pwd)' skills/merge-prs/SKILL.md
+grep -q 'Tier 1' skills/merge-prs/SKILL.md
+grep -q 'Tier 2' skills/merge-prs/SKILL.md
+grep -q 'Tier 3' skills/merge-prs/SKILL.md
+grep -q 'Tier 4' skills/merge-prs/SKILL.md
+grep -q '4-tier ladder\|four-tier\|Tier 1.*Tier 2.*Tier 3.*Tier 4' skills/merge-prs/SKILL.md
+```
+Expected: all exit 0.
+
+**Step 3: Commit**
+
+```bash
+git add skills/merge-prs/SKILL.md
+git commit -m "docs(merge-prs): update SKILL.md Conflict Resolution summary to 4-tier ladder"
+```
+
+**Acceptance Criteria:**
+- [ ] CWD Safety Guard preserved in SKILL.md measured by literal match verified by `grep -q 'CWD Safety Guard' skills/merge-prs/SKILL.md`
+- [ ] ORIG_DIR capture pattern preserved measured by literal match verified by `grep -q 'ORIG_DIR=\$(pwd)' skills/merge-prs/SKILL.md`
+- [ ] All four tiers referenced in SKILL.md measured by count verified by `test $(grep -c 'Tier [1234]' skills/merge-prs/SKILL.md) -ge 4`
+- [ ] Commit message contract referenced in SKILL.md summary measured by literal match verified by `grep -q 'merge: resolve conflict, verified by tests' skills/merge-prs/SKILL.md`
+- [ ] Reference to `references/conflict-resolution.md` preserved measured by literal match verified by `grep -q 'references/conflict-resolution.md' skills/merge-prs/SKILL.md`
+
+**Quality Constraints:**
+- Style: Numbered list matching the existing §Conflict Resolution section, fenced bash blocks for commands, bold emphasis for tier names
+- Terminology: "Tier 1", "Tier 2", "Tier 3", "Tier 4" (capitalized, with digit)
+- Preservation: Lines containing `git worktree add`, `git merge origin/`, and the entire CWD Safety Guard block must remain byte-for-byte identical — only the tier list and summary language change
+- Pattern: Reuse the numbered-step structure already present in §Conflict Resolution; do not introduce new top-level sections
+
+---
+
+### Task 8: Update SKILL.md Error Recovery table
+
+**Files:**
+- Modify: `skills/merge-prs/SKILL.md:253-265` (the Error Recovery table)
+
+**Step 1: Replace the "Merge conflict, behavioral" row**
+
+Delete the row:
+```
+| Merge conflict, behavioral | Pause for confirmation. If unresolved, skip with reason |
+```
+
+Add two new rows in its place:
+```
+| Merge conflict, structurally independent | Tier 2: attempt additive merge + run tests. Commit if green, escalate to Tier 3 if red. |
+| Merge conflict, semantic overlap | Tier 3: pause via `AskUserQuestion`, present diff + proposed resolution + test output. Always pauses regardless of mode. |
+```
+
+**Step 2: Verify**
+
+```bash
+! grep -q '^| Merge conflict, behavioral ' skills/merge-prs/SKILL.md
+grep -q 'Merge conflict, structurally independent' skills/merge-prs/SKILL.md
+grep -q 'Merge conflict, semantic overlap' skills/merge-prs/SKILL.md
+grep -q 'Tier 2: attempt additive merge' skills/merge-prs/SKILL.md
+grep -q 'Tier 3: pause' skills/merge-prs/SKILL.md
+```
+Expected: all exit 0.
+
+**Step 3: Commit**
+
+```bash
+git add skills/merge-prs/SKILL.md
+git commit -m "docs(merge-prs): split Error Recovery behavioral row into Tier 2 + Tier 3"
+```
+
+**Acceptance Criteria:**
+- [ ] Old "Merge conflict, behavioral" row removed measured by zero literal matches verified by `! grep -q '^| Merge conflict, behavioral ' skills/merge-prs/SKILL.md`
+- [ ] New structurally-independent row present measured by literal match verified by `grep -q 'Merge conflict, structurally independent' skills/merge-prs/SKILL.md`
+- [ ] New semantic-overlap row present measured by literal match verified by `grep -q 'Merge conflict, semantic overlap' skills/merge-prs/SKILL.md`
+- [ ] Tier 2 action description present measured by literal match verified by `grep -q 'Tier 2: attempt additive merge' skills/merge-prs/SKILL.md`
+- [ ] Tier 3 pause description present measured by literal match verified by `grep -q 'Tier 3: pause' skills/merge-prs/SKILL.md`
+
+**Quality Constraints:**
+- Style: Two new table rows matching the existing Error Recovery table format (`| Error | Action |`)
+- Terminology: "structurally independent" and "semantic overlap" (exact wording from Task 5 criteria)
+- Preservation: All other rows in the Error Recovery table (PR already merged, Auto-resolvable, CI failing, Unresolved review, GitHub API error) must remain unchanged
+- Pattern: Match column alignment and sentence style of adjacent rows (action is a short imperative or clause)
+
+---
+
+### Task 9: Update SKILL.md Config table with new merge.conflict_resolution fields
+
+**Files:**
+- Modify: `skills/merge-prs/SKILL.md:268-281` (the Config table)
+
+**Step 1: Add two new rows to the Config table**
+
+After the existing `ci_remediation.*` rows, add:
+```
+| `conflict_resolution.test_command` | *(none)* | Optional override for Tier 2 test runner. If unset, stack-based detection is used. See `references/conflict-resolution.md` § Test Runner Discovery. |
+| `conflict_resolution.test_timeout_minutes` | `5` | Hard wall-clock timeout for Tier 2 test verification. Minimum 1. |
+```
+
+**Step 2: Verify**
+
+```bash
+grep -q 'conflict_resolution.test_command' skills/merge-prs/SKILL.md
+grep -q 'conflict_resolution.test_timeout_minutes' skills/merge-prs/SKILL.md
+grep -q 'Optional override for Tier 2' skills/merge-prs/SKILL.md
+# Verify the row has a default value column:
+grep -E '^\| `conflict_resolution\.test_timeout_minutes` \| `5` \|' skills/merge-prs/SKILL.md
+```
+Expected: all exit 0.
+
+**Step 3: Commit**
+
+```bash
+git add skills/merge-prs/SKILL.md
+git commit -m "docs(merge-prs): add conflict_resolution config fields to SKILL.md Config table"
+```
+
+**Acceptance Criteria:**
+- [ ] test_command config row present measured by literal match verified by `grep -q 'conflict_resolution.test_command' skills/merge-prs/SKILL.md`
+- [ ] test_timeout_minutes config row present measured by literal match verified by `grep -q 'conflict_resolution.test_timeout_minutes' skills/merge-prs/SKILL.md`
+- [ ] test_timeout_minutes default value is 5 measured by exact row format verified by `grep -Eq '^\| \`conflict_resolution\.test_timeout_minutes\` \| \`5\` \|' skills/merge-prs/SKILL.md`
+- [ ] Row description references Tier 2 measured by literal match verified by `grep -q 'Optional override for Tier 2' skills/merge-prs/SKILL.md`
+- [ ] Both rows live inside the existing Config table measured by row count in the merge: config section verified by `awk '/^## Config/,/^---$/' skills/merge-prs/SKILL.md | grep -c 'conflict_resolution\.' | xargs test 2 -le`
+
+**Quality Constraints:**
+- Style: Two new table rows immediately after the existing `ci_remediation.*` rows, preserving column alignment
+- Terminology: Config key names match the `merge.conflict_resolution.*` convention introduced in Task 3 (exact byte match)
+- Preservation: All existing Config table rows must remain unchanged; only the two new rows are added
+- Pattern: Follow the 3-column table format (`| Field | Default | Description |`); `*(none)*` for optional fields without a default, literal backtick-wrapped values otherwise
+
+---
+
+## Issue #225 Acceptance Criteria Mapping
+
+Each of the 13 acceptance criteria from issue #225 maps to one or more tasks above:
+
+| # | Issue #225 Acceptance Criterion | Covered by Task(s) |
+|---|--------------------------------|---------------------|
+| 1 | `conflict-resolution.md` updated with Tier 2 section | Task 1 |
+| 2 | `conflict-resolution.md` updated with Tier 3 section | Task 2 |
+| 3 | Classification logic routes to appropriate tier | Task 5 |
+| 4 | Tier 2 verification loop: apply → test → commit-if-green → fall-through-if-red | Task 1 (procedure) + Task 5 (routing) |
+| 5 | Test suite discovery reuses `.feature-flow.yml`/project-file detection | Task 3 |
+| 6 | Worktree flow and CWD safety guard preserved | Task 7 (explicit preservation check) |
+| 7 | Tier 3 ALWAYS pauses, even in YOLO | Task 2 (safety invariant statement) |
+| 8 | Tier 3 presentation includes test output when Tier 2 failed | Task 2 (Presentation contents sub-bullet) |
+| 9 | SKILL.md §Conflict Resolution updated to describe the ladder | Task 7 |
+| 10 | Error recovery table entry updated | Task 8 |
+| 11 | Tier 2 commits use `merge: resolve conflict, verified by tests` format | Task 1 (contract) + Task 7 (SKILL.md reference) |
+| 12 | Test suite timeout enforced (default 5 minutes) | Task 4 (Timeout Detection) + Task 9 (Config default) |
+| 13 | Test suite failure falls through to Tier 3 (not Tier 4/skip) | Task 1 (fall-through language) + Task 5 (routing) |
+
+All 13 criteria are verifiable via the per-task grep-based acceptance checks above.
+
+---
+
+## Execution Notes
+
+- **TDD is N/A** for documentation-only changes. The "test" is grep-based content verification, which runs *after* the edit. Treat each task's "Verify" step as the test phase.
+- **One commit per task** for reviewability.
+- **Task ordering matters:** Tasks 1-6 edit `conflict-resolution.md`; Tasks 7-9 edit `SKILL.md`. Tasks 1-4 should complete before Task 5 (routing references Tier 2) and Task 6 (example references Tier 2). Task 7 should complete before Tasks 8-9 (summary references the table/config that follow).
+- **No tests will be added to `tests/`** — there is no test directory; the project is Markdown-only.

--- a/docs/plans/2026-04-08-graduated-conflict-resolution.md
+++ b/docs/plans/2026-04-08-graduated-conflict-resolution.md
@@ -1,0 +1,326 @@
+# Graduated Merge Conflict Resolution with Test Verification — Design Document
+
+**Date:** 2026-04-08
+**Status:** Draft
+**Issue:** #225
+**Scope:** feature
+**Dependency:** #224 (merged — `skills/merge-prs/references/best-effort-remediation.md` exists)
+
+---
+
+## Overview
+
+Expand `merge-prs` conflict resolution from the current binary (trivial auto-resolve / behavioral pause) into a **4-tier resolution ladder** that attempts a complete, reasonable resolution before pausing. Tier 2 (NEW) attempts a structurally-safe merge and verifies it by running the project test suite; Tier 3 (NEW) presents the proposed resolution plus test output to the user for a decision. Pausing becomes the last resort, not the first response to any both-sided modification.
+
+---
+
+## Example
+
+**Scenario:** PR #482 modifies `src/auth/login.ts`. Main branch simultaneously received a change that added rate-limiting to the same `validateUser()` function. PR #482 added password-strength checking to `validateUser()`. Both sides touch the same function but add logically independent code blocks.
+
+**Current behavior (pre-#225):**
+```
+YOLO: ship — Behavioral conflict in PR #482 (src/auth/login.ts:42) → paused
+```
+User must manually resolve every such conflict, even when the resolution is mechanical.
+
+**New behavior (post-#225):**
+```
+YOLO: ship — Conflict in PR #482 (src/auth/login.ts:42) → Tier 2 attempt
+  → Structural independence check: both sides add non-overlapping lines inside validateUser() scope
+  → Applying additive merge...
+  → Detected test runner: pnpm test (from pnpm-lock.yaml)
+  → Running: timeout 300 pnpm test
+  → Tests passed after 01:47
+  → Committed: merge: resolve conflict, verified by tests
+  → Pushed. Proceeding to merge.
+```
+
+If tests had failed, the flow would instead escalate to Tier 3:
+```
+YOLO: ship — Tier 2 tests failed in PR #482 → Tier 3 pause
+  → Discarded attempt (git checkout -- .)
+  → Captured test output (42 lines)
+  → Presenting to user...
+```
+
+---
+
+## Algorithm
+
+### Step 1 — Structure classification (unchanged)
+
+When a PR reports `mergeable: "CONFLICTING"`, create the conflict-resolution worktree (unchanged, at `SKILL.md:229-236`). For each conflict hunk, run the existing Structure Classification (`conflict-resolution.md:28-44`):
+
+| Structure | Route to |
+|-----------|----------|
+| Import ordering / whitespace / lockfile / generated / adjacent-additions / one-sided modification | **Tier 1** (unchanged) |
+| Both-sided modification (structurally independent — see Step 2) | **Tier 2** (NEW) |
+| Both-sided modification (semantic overlap) | **Tier 3** (NEW) |
+| Unknown structure (malformed markers, unusual format) | **Tier 3** (conservative) |
+
+### Step 2 — Structural independence gate (NEW)
+
+**Where Tier 2 fits:** The existing `adjacent additions` rule (`conflict-resolution.md:32`) already routes cases where both blocks contain ONLY new lines to Tier 1 (trivial). Tier 2 targets a different gap: **cases the behavioral keyword check currently over-flags** (`conflict-resolution.md:68-72`). Those are both-sided modifications where behavioral keywords appear in the conflict region, so keyword-matching escalates them to "behavioral → pause" — but where an additive union merge is still mechanically safe because the changes target non-overlapping semantic scopes within the region.
+
+Apply these rules in order:
+
+1. **Behavioral keyword check would flag, but changes are semantically non-overlapping** — structure classifier reports both-sided modification, behavioral keywords (`if`, `return`, `throw`, `expect(`, etc.) appear in at least one block, AND both blocks introduce their behavioral constructs in distinct statements without modifying a shared statement from the merge base. Example: both sides add a new statement containing `return` inside the same function, but at different positions around a shared `return baseResult()`. → **Tier 2 eligible**.
+2. **Both blocks modify different declarations within the same file** — e.g., one side modifies function `foo()`, the other modifies function `bar()`, and the conflict region spans both. → **Tier 2 eligible**.
+3. **Both blocks modify overlapping lines that existed in the merge base** — e.g., both sides change the same `if` condition differently, or both sides rewrite the same return statement. → **Tier 3 only** (semantic overlap — additive merge would produce contradictory logic).
+4. **Marker parsing ambiguous or blocks contain conflicting imports that Tier 1 did not resolve** → **Tier 3** (conservative).
+
+**Invariant:** Tier 2 is ONLY invoked for cases that would currently be flagged behavioral. Cases already caught by `one-sided modification`, `adjacent additions`, or `context-only keywords` continue to resolve as Tier 1 with no change.
+
+### Step 3 — Tier 2: attempt-with-test-verification (NEW)
+
+Pre-conditions: structural independence gate passed (Step 2 rule 1 or 2).
+
+1. **Attempt additive merge** — write the merged file with both blocks concatenated in their original order.
+2. **Discover test runner** — see § Test Runner Discovery below. If no runner found → discard attempt and fall through to Tier 3.
+3. **Run tests with timeout** — invoke the discovered command under a hard wall-clock limit (default 5 minutes, configurable via `merge.conflict_resolution.test_timeout_minutes`).
+4. **Interpret result:**
+   - Exit code 0 and within timeout → **tests passed** → commit with the exact message `merge: resolve conflict, verified by tests` and push. Exit conflict resolution, proceed to merge.
+   - Non-zero exit code OR timeout OR runner crash → **tests failed** → `git checkout -- .` to discard the attempt, capture the combined stdout+stderr (trimmed to 80 lines) into a variable, fall through to Tier 3.
+
+### Step 4 — Tier 3: attempt-with-diff-presentation (NEW)
+
+Always pauses via `AskUserQuestion`, regardless of mode.
+
+**Presentation contents:**
+- The raw conflict diff (trimmed to 40 lines if longer)
+- The proposed resolution Tier 2 computed (if any — omit if Tier 2 was skipped at structural gate)
+- Test failure output (if any — omit if Tier 2 was skipped)
+
+**Options shown:**
+1. `Accept proposed` — take the Tier 2 merge attempt even though tests failed (user override)
+2. `Accept ours` — keep the current base branch version
+3. `Accept theirs` — take the incoming branch version
+4. `I'll resolve manually` — pause, let user edit files in the worktree, then resume when they confirm
+
+If user selects `Skip this PR` via the "Other" escape hatch: fall through to Tier 4.
+
+### Step 5 — Tier 4: skip (last resort)
+
+Only reached when Tier 3 is declined or manual resolution fails. Log reason, report in Ship Phase Summary, continue with next PR.
+
+---
+
+## Test Runner Discovery
+
+A new helper section in `conflict-resolution.md` (inline — not a separate file) documents how Tier 2 discovers the test runner for the *consumer project* being merged. This pattern is **reusable** for any future remediation loop that needs to run local tests.
+
+### Discovery order (first match wins)
+
+1. **Explicit config:** `merge.conflict_resolution.test_command` in `.feature-flow.yml` — if set, use verbatim and stop.
+2. **Stack-based detection** from the `stack:` field in `.feature-flow.yml`:
+   - If stack contains `node-js`:
+     - `pnpm-lock.yaml` exists → `pnpm test`
+     - `yarn.lock` exists → `yarn test`
+     - `package-lock.json` exists → `npm test`
+     - `package.json` exists (no lockfile) → `npm test`
+   - If stack contains `python`:
+     - `pytest.ini`, `pyproject.toml` with `[tool.pytest]`, or `setup.cfg` with `[tool:pytest]` exists → `pytest`
+     - `pyproject.toml` without pytest config, `setup.py` exists → `python -m pytest`
+3. **No match** → return `None`. Tier 2 is skipped; conflict escalates to Tier 3 with reason `test-runner-not-found`.
+
+### Timeout command detection
+
+macOS does not ship GNU `timeout`. Detect at runtime (once per merge-prs invocation):
+```bash
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+else
+  TIMEOUT_CMD=""  # fall back to background-job pattern
+fi
+```
+
+**Fallback pattern (no `timeout`/`gtimeout` available):**
+```bash
+( eval "$TEST_CMD" ) &
+TEST_PID=$!
+( sleep "$TIMEOUT_SECONDS" && kill -TERM "$TEST_PID" 2>/dev/null ) &
+KILLER_PID=$!
+wait "$TEST_PID"; TEST_EXIT=$?
+kill -TERM "$KILLER_PID" 2>/dev/null
+```
+Non-zero exit from `wait` after the kill signal is interpreted as `timeout`.
+
+---
+
+## Mode Behavior
+
+| Mode | Tier 1 | Tier 2 | Tier 3 | Tier 4 |
+|------|--------|--------|--------|--------|
+| **YOLO** | Auto, announce | Auto attempt + auto commit on green | **Always pause** (safety invariant) | Auto-skip with reason |
+| **Express** | Auto, announce | Auto attempt + auto commit on green | **Always pause** (safety invariant) | Auto-skip with reason |
+| **Interactive** | Auto, announce | Confirm attempt; confirm commit on green | Always pause | Confirm skip |
+
+**Safety invariant (must never be violated):** Tier 3 ALWAYS pauses, even in YOLO mode. This is the single non-negotiable rule of the new design.
+
+---
+
+## Announcement Formats
+
+All formats follow the existing `best-effort-remediation.md` template style. `<MODE>` is `YOLO`, `Express`, or `Interactive`.
+
+**Tier 2 attempt start:**
+```
+<MODE>: ship — Conflict in PR #<N> (<file>:<scope>) → Tier 2 attempt
+  → Structural independence check: <reason passed>
+  → Applying additive merge...
+  → Detected test runner: <command> (<source>)
+  → Running: <TIMEOUT_CMD> <seconds> <command>
+```
+
+**Tier 2 success:**
+```
+  → Tests passed after <mm:ss>
+  → Committed: merge: resolve conflict, verified by tests
+  → Pushed. Proceeding to merge.
+```
+
+**Tier 2 failure escalating to Tier 3:**
+```
+  → Tests failed after <mm:ss> (exit <code>)
+<MODE>: ship — Tier 2 tests failed in PR #<N> → Tier 3 pause
+  → Discarded attempt (git checkout -- .)
+  → Captured test output (<lines> lines)
+  → Presenting to user...
+```
+
+**Tier 2 skipped (no runner):**
+```
+<MODE>: ship — Tier 2 skipped in PR #<N> → Tier 3 (reason: test-runner-not-found)
+```
+
+**Tier 3 resolution:**
+```
+<MODE>: ship — PR #<N> Tier 3 resolved → <user_choice>
+```
+
+**Tier 4 skip:**
+```
+<MODE>: ship — PR #<N> skipped: conflict unresolved (Tier 4)
+```
+
+---
+
+## Shared Infrastructure
+
+This feature **consumes** (does not modify) `skills/merge-prs/references/best-effort-remediation.md` (created by #224). Specifically it reuses:
+- Mode-aware escalation patterns for the announcement templates
+- The skip/pause/escalate decision table (adds Tier 3 pause as a new row)
+- The wall-clock tracking guidance (applied to the test-runner timeout)
+
+It does NOT plug into the bounded-attempt loop skeleton — Tier 2 is a single-shot attempt (not a loop), because the fix (additive merge) is deterministic. If tests fail, the resolution can't be iterated without human judgment, so the flow falls through to Tier 3.
+
+---
+
+## Config Schema Additions
+
+New optional section in `.feature-flow.yml`:
+```yaml
+merge:
+  conflict_resolution:
+    test_command: "pnpm test"                # optional — overrides stack detection
+    test_timeout_minutes: 5                   # optional — default 5, minimum 1
+```
+
+All fields optional. Absence preserves current behavior (stack-based detection with 5-minute default).
+
+---
+
+## Patterns & Constraints
+
+### Error Handling
+- **No bare `catch (e) {}`** — the hook blocks empty catches. All error handling is explicit: on test runner crash, capture stderr and treat as "tests failed" → Tier 3.
+- **Wall-clock timeout enforced** — the `timeout` command (or bash kill fallback) must kill the test process after `test_timeout_minutes` × 60 seconds. Treat SIGTERM as "tests failed" with reason `timeout`.
+- **Git safety** — always `git checkout -- .` to discard failed attempts before falling through. Never leave partial resolutions in the worktree.
+
+### Types (markdown documentation only — no runtime types)
+- Exit code conventions: `0 = pass`, `1-127 = fail`, `>128 = killed by signal`
+- Mode flags: literal strings `YOLO | Express | Interactive`
+
+### Performance
+- Tier 2 timeout defaults to 5 minutes. Long-running test suites must set `test_timeout_minutes` explicitly or Tier 2 will kill them mid-run.
+- Minimum poll granularity for the bash kill fallback is 1 second.
+
+### Stack-Specific
+- **macOS** does not ship `timeout` — detection and fallback are mandatory.
+- **Lockfile detection** must handle the case where multiple lockfiles exist (choose the one matching `packageManager` field in `package.json` if present; else prefer `pnpm` > `yarn` > `npm` for deterministic ordering).
+
+### CWD Safety
+- The existing CWD safety guard at `SKILL.md:245-249` is preserved verbatim. Tier 2 runs **inside** the existing conflict-resolution worktree — no new worktree is created, no new CWD transitions are introduced.
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `skills/merge-prs/references/conflict-resolution.md` | Add §Tier 2, §Tier 3, §Test Runner Discovery, §Timeout Detection. Update Structure Classification routing: after the existing behavioral keyword check, insert a structural-independence gate that routes eligible both-sided modifications to Tier 2; all other behavioral cases route to Tier 3. Rename "Behavioral Conflicts" section to "Tier 3: Diff Presentation" with updated option list. Add **Example 7** (new): a keyword-triggered but structurally-independent both-sided modification routed to Tier 2, showing both success (tests pass → commit) and failure (tests fail → escalate to Tier 3). |
+| `skills/merge-prs/SKILL.md` | §Conflict Resolution (lines 223-249): update summary to describe the 4-tier ladder and reference the new sections. §Error Recovery table: replace the "Merge conflict, behavioral" row with two rows — "Merge conflict, structurally independent → Tier 2" and "Merge conflict, semantic overlap → Tier 3 (pause)". §Config table: add `merge.conflict_resolution.test_command` and `merge.conflict_resolution.test_timeout_minutes` rows with defaults. |
+| `.feature-flow.yml` | **No change required** — new config fields are optional and absent fields use defaults. |
+
+**Not modified:**
+- `skills/merge-prs/references/best-effort-remediation.md` — consumed only, not edited.
+- `skills/merge-prs/references/ci-remediation.md` — independent remediation loop, unaffected.
+
+---
+
+## Scope
+
+### Included
+- Tier 2 and Tier 3 added to `conflict-resolution.md` with full specifications
+- Structural independence gate logic defined
+- Test runner discovery algorithm (config override + stack-based detection)
+- Timeout command detection + bash fallback
+- Mode behavior table covering Tier 2 and Tier 3
+- Announcement templates matching existing style
+- Commit message format `merge: resolve conflict, verified by tests`
+- Config schema additions in `.feature-flow.yml` (optional)
+- Updated Error Recovery and Config tables in `SKILL.md`
+- Examples showing Tier 2 success and Tier 2-to-Tier 3 escalation
+
+### Explicitly Excluded
+- **Loop / retry behavior for Tier 2** — single-shot only. If tests fail, escalate to Tier 3. Retry requires human judgment and is out of scope.
+- **Sandboxing the test run** — tests run in the existing worktree with the user's normal environment. No container/chroot isolation.
+- **Parallel test runners** — Tier 2 runs one test command synchronously.
+- **Test result caching** — no reuse of prior test results across PRs.
+- **Changes to Tier 1 classification** — Tier 1 auto-resolve rules are unchanged.
+- **Runtime code** — feature-flow is a Markdown-only skill plugin; no TypeScript/Python implementation is added.
+
+---
+
+## Acceptance Criteria (from issue #225)
+
+- [ ] `skills/merge-prs/references/conflict-resolution.md` updated with Tier 2 (attempt-with-test-verification) section
+- [ ] `skills/merge-prs/references/conflict-resolution.md` updated with Tier 3 (attempt-with-diff-presentation) section
+- [ ] Classification logic routes conflicts to the appropriate tier based on structure + verification outcomes
+- [ ] Tier 2 verification loop: apply → test → commit-if-green → fall-through-if-red
+- [ ] Test suite discovery reuses `.feature-flow.yml` / project-file detection (shared with CI remediation)
+- [ ] Worktree flow and CWD safety guard at `SKILL.md:224-249` preserved
+- [ ] Tier 3 ALWAYS pauses, even in YOLO mode (safety invariant)
+- [ ] Tier 3 presentation includes test output when Tier 2 failed
+- [ ] `skills/merge-prs/SKILL.md` §Conflict Resolution updated to describe the ladder
+- [ ] Error recovery table entry for "Merge conflict, behavioral" updated to reflect new ladder
+- [ ] Commits from Tier 2 use `merge: resolve conflict, verified by tests` format
+- [ ] Test suite timeout enforced (default 5 minutes)
+- [ ] Test suite failure falls through to Tier 3 (not Tier 4/skip)
+
+---
+
+## Open Questions
+
+None. All decisions self-answered from the issue body and existing codebase patterns.
+
+---
+
+## Next Steps
+
+1. Run `design-verification` to check this design against the codebase
+2. Update issue #225 with the final design via `create-issue`
+3. Run `writing-plans` to create an implementation plan with per-task acceptance criteria

--- a/docs/plans/2026-04-08-merge-prs-review-triage-implementation.md
+++ b/docs/plans/2026-04-08-merge-prs-review-triage-implementation.md
@@ -1,0 +1,699 @@
+# PR Review Triage Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the binary `CHANGES_REQUESTED` skip in `skills/merge-prs/SKILL.md:89` with a single-pass triage flow that fetches inline review comments, discussion comments, and formal reviews; classifies each unresolved thread into one of 6 categories (blocker/suggestion/nit/question/praise/unclear); attempts best-effort remediation; and replies to threads with fix commit attribution.
+
+**Architecture:** Create `skills/merge-prs/references/review-triage.md` as the review-specific specialization of the shared `best-effort-remediation.md` pattern (mirrors `ci-remediation.md` structure). Then wire it into `SKILL.md` Step 4a (parallel fetch extension + triage flow replacing the binary skip), update the error recovery table row for "Unresolved review requests", extend `.feature-flow.yml` with the new `merge.wait_for_rereview` config field, and mark review triage as a current consumer in `best-effort-remediation.md`.
+
+**Tech Stack:** Markdown only — no executable code, no Python/TS, no test files. All changes are prompt-instruction documents consumed by Claude at runtime.
+
+**Design doc:** `docs/plans/2026-04-08-merge-prs-review-triage.md`
+
+**Depends on:** Issue #224 (closed). Confirmed: `skills/merge-prs/references/best-effort-remediation.md` exists and contains the shared attempt loop skeleton and mode escalation contract.
+
+---
+
+## Conventions to Know Before Starting
+
+1. **Reference file header sentence** — every file in `skills/merge-prs/references/` starts with exactly one sentence in the form:
+   `Reference file for the \`merge-prs\` skill. Read this file when <condition>.`
+   See `skills/merge-prs/references/ci-remediation.md:3` for the closest sibling example.
+
+2. **Reference file section layout** — specialization files follow this section order (as established by `ci-remediation.md`):
+   Overview → Detection/Fetch → Classification → Fix Strategies Per Category → Commit Message Contract → Verify/Polling → Reference Back to Shared File.
+
+3. **Table style** — pipe syntax with a header-separator row. Column names are Title-cased.
+
+4. **Announce format** — backtick-wrapped literal output strings, mode-prefixed (`YOLO:`, `Express:`, `Interactive:`).
+
+5. **`.feature-flow.yml` comment style** — hash-comments with `# field: value   # <type> (default: <value>)` alignment. See lines 24-33 of `.feature-flow.yml` for the exact indentation and spacing to match.
+
+6. **SKILL.md current text at line 89** (the binary `CHANGES_REQUESTED` skip that this plan replaces):
+   `- If \`reviews\` has any \`CHANGES_REQUESTED\` state: flag to user, skip PR. Announce reason.`
+
+7. **SKILL.md current error recovery row for reviews** (approximately line 263):
+   `| Unresolved review requests | Skip with reason |`
+
+8. **`best-effort-remediation.md` "Current consumers" list** (lines 11-14 currently) still lists review triage as "future" — this plan updates it.
+
+9. **Paths in this plan are relative** (e.g. `skills/merge-prs/references/review-triage.md`) and work from either the main repo root OR a worktree root.
+
+---
+
+### Task 1: Create `skills/merge-prs/references/review-triage.md`
+
+**Files:**
+- Create: `skills/merge-prs/references/review-triage.md`
+
+**Step 1: Verify the references directory exists**
+
+Run:
+```bash
+ls skills/merge-prs/references/
+```
+Expected: see `best-effort-remediation.md`, `ci-remediation.md`, `conflict-resolution.md`, `dependency-analysis.md`, `CLAUDE.md`. If `best-effort-remediation.md` is missing, STOP — dependency #224 is not in place.
+
+**Step 2: Write the file**
+
+Create `skills/merge-prs/references/review-triage.md` with exactly this content:
+
+````markdown
+# Review Triage
+
+Reference file for the `merge-prs` skill. Read this file when a PR has any unresolved inline review comments, discussion comments, or `CHANGES_REQUESTED` formal reviews — enter the single-pass triage flow described here.
+
+See `references/best-effort-remediation.md` for the attempt loop skeleton and mode escalation contract. This file specializes only the review-triage-specific portions.
+
+---
+
+## Overview
+
+When the pre-merge fetch in `SKILL.md` Step 4a returns any unresolved review threads or discussion comments, do not skip the PR without attempting remediation. Instead, enter the single-pass triage flow:
+
+- **MAX_ATTEMPTS:** 1 (review triage is atomic per PR — one classify + fix + reply pass)
+- **MAX_WALL_CLOCK:** 10 minutes (overridable — shares the same budget semantics as the shared skeleton)
+- **POLL_INTERVAL:** not applicable (no polling cycle; unlike ci-remediation there is no "wait for tests to rerun" step)
+
+Fetch all three feedback surfaces in parallel, filter stale/resolved/self-reply threads, classify each remaining thread into exactly one category, dispatch to the matching fix strategy, commit and push all fixes in per-(reviewer, file) groups, post replies tying each thread to its fix commit, and post a single re-review comment if any blockers were addressed.
+
+---
+
+## Fetch Commands
+
+Three parallel `gh` calls gather all feedback surfaces:
+
+**1. Review threads with resolution state (GraphQL — canonical):**
+
+```bash
+gh api graphql -F owner=<owner> -F name=<repo> -F number=<pr> -f query='
+  query($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            path
+            line
+            originalLine
+            startLine
+            comments(first: 50) {
+              nodes {
+                id
+                databaseId
+                author { login }
+                body
+                createdAt
+                diffHunk
+                line
+                originalLine
+                path
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+'
+```
+
+REST `repos/.../pulls/N/comments` does NOT expose `isResolved` or `isOutdated` — always use the GraphQL query above.
+
+**2. Discussion comments (REST — flat list, not anchored to files):**
+
+```bash
+gh api "repos/<owner>/<repo>/issues/<pr>/comments"
+```
+
+**3. Current actor (cached once per batch — used for self-reply filter):**
+
+```bash
+gh api user --jq .login
+```
+
+The existing `gh pr view ... --json reviews` call (already in Step 4a) continues to fetch formal review states. Keep it — do not remove it.
+
+---
+
+## Thread Filtering Rules
+
+Apply these four filters in order to every fetched thread. A thread that matches any filter is dropped from classification.
+
+| Filter | Condition | Applies To |
+|--------|-----------|------------|
+| **Outdated** | `isOutdated == true` in the GraphQL result | reviewThreads only (discussion comments have no `isOutdated` field) |
+| **Resolved** | `isResolved == true` in the GraphQL result | reviewThreads only |
+| **Self-reply** | All comments in the thread have `author.login == <current_actor>` — the current actor login is fetched once at Step 4a entry and cached for the batch | reviewThreads AND discussion comments |
+| **Addressed by later approval** | The most recent formal review by the thread's original commenter is `APPROVED` AND that review's `submittedAt` is after the thread's most recent comment by that reviewer | reviewThreads AND discussion comments |
+
+**Self-reply rule detail:** If a thread contains a mix of self-replies AND non-self comments, drop only the self-reply comments and keep the thread. If after dropping self-replies the thread has no remaining comments, drop the thread entirely. This prevents merge-prs from re-processing its own past fix replies as new feedback.
+
+**Stale line filter:** Any reviewThread whose `line` field is `null` in the GraphQL result is treated as outdated (the anchor line no longer exists in the current file) and dropped.
+
+---
+
+## Classification Heuristics
+
+Assign exactly one category per surviving thread. Apply rules top-to-bottom — **the first matching row wins**. Priority order is safety-first: a comment containing "crash" prefixed with "nit:" is still a `blocker`.
+
+| Priority | Category | Detection pattern | Example |
+|----------|----------|-------------------|---------|
+| 1 | `blocker` | Comment body (case-insensitive) contains any of: `must`, `will crash`, `security`, `broken`, `blocker`, `vulnerability`, `data loss`, `exploit` — OR the thread is anchored to a formal review with `state == "CHANGES_REQUESTED"` | `"this will crash on empty input — needs a null check"` |
+| 2 | `suggestion` | Comment body contains a ` ```suggestion ` fenced code block | Contains `` ```suggestion\nstr.split(/,\s*/)\n``` `` |
+| 3 | `nit` | Comment starts with (case-insensitive) `nit:`, `style:`, `minor:`, `typo:`, `small:` — OR is purely about formatting (`indent`, `whitespace`, `semicolon`, `trailing comma`) | `"nit: typo — 'recieve' → 'receive'"` |
+| 4 | `question` | Comment body ends with `?` OR starts with (case-insensitive) `why`, `what`, `how`, `when`, `is this`, `should`, `could` | `"why is this cast needed here?"` |
+| 5 | `praise` | Comment body (trimmed, case-insensitive) matches one of: `lgtm`, `looks good`, `nice`, `approved`, `👍`, `:+1:`, `ship it` — and contains nothing else substantive | `"lgtm 👍"` |
+| 6 | `unclear` | None of the above — conservative fallback | *(anything not matching rows 1-5)* |
+
+**Assignment rule:** Each surviving thread gets exactly one category. The priority order is fixed — a comment matching multiple patterns takes the highest-priority (lowest row number) match.
+
+---
+
+## Fix Strategies Per Category
+
+| Category | Action | GitHub API call | Commit behavior |
+|----------|--------|------------------|-----------------|
+| `blocker` | Read the source file and anchor line from `path` + `line`. Understand the comment intent. Apply a minimal targeted fix via `Edit`. If the fix is ambiguous, the patch fails to apply, or the intent cannot be determined from the comment + code context alone, mark the thread **unfixable** and fall through to mode-aware escalation. Do not refactor beyond the exact concern raised. | `POST repos/{owner}/{repo}/pulls/{pr}/comments` with `-F in_reply_to=<databaseId>` and `-f body="Addressed in <sha>. <summary>"` | Commit with `fix: address review comment by @<reviewer> on <file>:<line>` |
+| `suggestion` | Parse the ` ```suggestion ` fenced block from comment body (may be single-line or multi-line). Read the file at `line` (single-line) or `startLine..line` (multi-line). Replace exactly. If patch apply fails, retry once with 3-way merge semantics. If still failing, mark unfixable. | Same as blocker (`in_reply_to` on the inline comment) with body `"Applied suggestion in <sha>"` | Commit with `fix: apply suggestion from @<reviewer> on <file>:<line>` |
+| `nit` | If the fix is obvious from the comment body (e.g., typo replacement with explicit before/after, missing semicolon, obvious formatting), apply via `Edit`. If the fix is not obvious from the comment body alone, mark unfixable and fall through. Do NOT guess. | Same as blocker (`in_reply_to` on the inline comment) with body `"Addressed in <sha>: <summary>"` | Commit with `fix: address nit from @<reviewer> on <file>:<line>` |
+| `question` | Read the source file at the anchor line (if inline) or read the PR summary/relevant files (if discussion). Generate a context-aware answer based on the code. Post as reply — no code change, no commit. | For inline: `POST repos/{owner}/{repo}/pulls/{pr}/comments` with `in_reply_to=<databaseId>`. For discussion: `gh pr comment <pr> --body "<answer>"`. | No commit (reply-only) |
+| `praise` | No action. No reply. Record internally as "acknowledged". Does not block merge. | None | None |
+| `unclear` | Do not attempt to auto-resolve. Fall through to mode-aware escalation in Step 6. | None | None |
+
+**Suggestion block parser:** Extract content between ` ```suggestion ` and ` ``` ` fences. Multi-line suggestions are delimited by `start_line` (first line to replace) and `line` (last line to replace) fields in the GraphQL result. Single-line suggestions use `line` only.
+
+**Reply endpoint selection:**
+- Inline review thread (has `path` and `line`): `POST repos/{owner}/{repo}/pulls/{pr}/comments` with `in_reply_to=<databaseId>` (integer — use `-F` not `-f`)
+- Discussion comment (no `path`): `gh pr comment <pr> --body "..."` (PR-level comment)
+- Formal review ack (when replying to a review body, not an inline comment): `gh pr review <pr> --comment --body "..."`
+
+**Identifier rule:** When calling `in_reply_to`, use the integer `databaseId` field from the GraphQL comment node — NOT the string `id` (GraphQL global node ID). The REST reply endpoint requires the integer database ID.
+
+---
+
+## Commit Grouping and Message Contract
+
+**Grouping rule:** Group applied fixes by `(reviewer, file)` tuple. One commit per tuple. This keeps git log attributable per reviewer and per touched file.
+
+**Single-thread commit format:**
+```
+fix: address review comment by @<reviewer> on <file>:<line>
+```
+
+**Multi-thread commit format (2+ threads in same (reviewer, file) group):**
+```
+fix: address review comments by @<reviewer>
+
+- <file>:<line> — <brief summary of fix>
+- <file>:<line> — <brief summary of fix>
+```
+
+**Rule:** Use the `fix:` prefix (no scope suffix) to distinguish from `fix(ci):` used by ci-remediation. The `fix:` prefix alone signals "review feedback addressed".
+
+**Examples:**
+```
+fix: address review comment by @alice on src/api/handler.ts:42
+```
+
+```
+fix: apply suggestion from @carol on src/utils/parse.ts:17
+```
+
+```
+fix: address review comments by @alice
+
+- src/api/handler.ts:42 — added null check for empty input
+- src/api/handler.ts:58 — added error return path for parse failure
+```
+
+---
+
+## Reply Templates
+
+Use these exact templates. Replace placeholders in `<angle brackets>`.
+
+**Fix applied (blocker, suggestion, nit — inline reply via `in_reply_to`):**
+```
+Addressed in <sha>. <one-line summary of what was changed>
+```
+
+**Suggestion applied (specialization of above):**
+```
+Applied suggestion in <sha>.
+```
+
+**Question answer (context-aware — generated from code; no fixed template):**
+Generate a concise, factual answer based on reading the anchored file and line. Keep it under 3 sentences. Do not speculate — if the answer isn't clear from the code, classify as `unclear` instead.
+
+**Praise (no reply posted — internal acknowledgement only):**
+*(none)*
+
+**Re-review summary comment (posted once per PR if any blockers were addressed):**
+
+```bash
+gh pr comment <pr> --body "@<reviewer1> @<reviewer2> addressed N review comments in latest commits:
+- <file>:<line> — <brief fix summary>
+- <file>:<line> — <brief fix summary>
+
+Ready for re-review."
+```
+
+The reviewers in the `@mention` list are the union of all reviewers whose blocker threads were addressed. Do NOT `@`-mention reviewers whose only contributions were praise, addressed-question replies, or addressed-nit replies — those are already handled by the inline thread replies.
+
+---
+
+## Mode Behavior
+
+See `references/best-effort-remediation.md § Mode-Aware Escalation Contract` for the base contract. Review-triage specifics:
+
+| Mode | Questions | Nits / Suggestions | Blockers | Unclear |
+|------|-----------|--------------------|----------|---------|
+| **YOLO** | Auto-generate reply + announce | Auto-fix + reply + announce | Attempt fix; if unfixable → skip PR | Skip PR (reason: `N unclear review threads require manual triage`) |
+| **Express** | Confirm first reply per category via `AskUserQuestion` (show generated text), then auto for rest | Confirm first fix per category (show diff), then auto for rest | Confirm each fix via `AskUserQuestion` (show diff) | Pause via `AskUserQuestion` — options: "Address manually", "Skip PR", "Proceed anyway (override)" |
+| **Interactive** | Confirm each reply (show generated text per thread) | Confirm each fix (show diff per thread) | Confirm each fix (show diff per thread) | Pause via `AskUserQuestion` per thread |
+
+**Safety invariant (all modes):** A blocker that cannot be auto-fixed ALWAYS pauses (Express/Interactive) or skips (YOLO) — it is NEVER merged over. An `unclear` thread ALWAYS pauses (Express/Interactive) or skips (YOLO).
+
+---
+
+## `wait_for_rereview` Polling Behavior
+
+Read `.feature-flow.yml` `merge.wait_for_rereview` (default: `false`).
+
+**When `false` (default):** After posting fix replies and the re-review comment, proceed immediately to the CI check step. Do not wait for the reviewer to respond. Trust the fix.
+
+**When `true`:** After posting the re-review comment, poll `gh pr view <pr> --json reviews --jq '.reviews[-1]'` every 60 seconds for up to 10 minutes or until the MAX_WALL_CLOCK budget is exhausted:
+
+- If a new review appears with `state == "APPROVED"` → proceed to CI check.
+- If a new review appears with `state == "CHANGES_REQUESTED"` → skip PR with reason `re-review requested changes after auto-fix`.
+- If 10 minutes elapse with no new review → proceed to CI check (timeout-trust).
+
+---
+
+## Re-Review Comment Template
+
+When any blocker threads have been successfully addressed, post a single summary comment at the end of the triage flow (after all inline replies):
+
+```bash
+gh pr comment <pr> --body "$(cat <<EOF
+@<reviewer1> @<reviewer2> addressed <N> review comments in the latest commits:
+
+- <file1>:<line1> — <brief summary>
+- <file2>:<line2> — <brief summary>
+
+Ready for re-review.
+EOF
+)"
+```
+
+Do NOT post a re-review comment if only nits/suggestions/questions were addressed — inline replies suffice for those. The re-review comment exists specifically to notify reviewers that safety-critical feedback was acted on.
+
+---
+
+## Error Handling
+
+- **`gh api` failures** (non-zero exit, network error, 5xx, rate limit): retry once after 5 seconds. If still failing, log and skip the thread — do not crash the triage. If the initial GraphQL fetch fails entirely, skip the PR with reason `"review fetch failed"`.
+- **Patch apply failures** (suggestion block or blocker fix doesn't apply cleanly): retry once with relaxed context (3-way merge equivalent). If still failing, mark the thread unfixable and fall through to mode-aware escalation.
+- **Git push rejection** (non-fast-forward): fetch + rebase once, re-push. If still rejected, skip PR with reason `push rejected after rebase`.
+- **Reply post failure**: if `gh api ... -F in_reply_to=<id>` fails after the retry, the commit is already pushed — log the failure but do NOT rollback. The fix stands; the reviewer will see the commit in the GitHub UI.
+- **Self-reply loop prevention**: filter 3 (self-reply) is enforced BEFORE classification so merge-prs never sees its own past replies as new threads. This is mandatory — skipping this filter causes infinite loops when merge-prs is the PR author.
+
+---
+
+## Reference Back to Shared File
+
+This file specializes the loop defined in `references/best-effort-remediation.md`:
+
+- **Attempt loop skeleton** → `best-effort-remediation.md § Attempt Loop Skeleton` (with `MAX_ATTEMPTS=1`)
+- **Mode-aware escalation** → `best-effort-remediation.md § Mode-Aware Escalation Contract`
+- **Announcement templates** → `best-effort-remediation.md § Announcement Format Templates`
+- **Skip/pause/escalate decisions** → `best-effort-remediation.md § Decision Table`
+- **Wall-clock tracking** → `best-effort-remediation.md § Wall-Clock Tracking Guidance`
+
+Review-triage-specific parameters:
+- `detect_failures()` → Fetch Commands + Thread Filtering Rules + Classification Heuristics (above)
+- `apply_fix(thread)` → Fix Strategies Per Category (above)
+- `verify_success()` → not applicable (single-pass; optional `wait_for_rereview` polling instead)
+- `build_commit_message()` → Commit Grouping and Message Contract (above)
+````
+
+**Step 3: Verify the file was created with required strings**
+
+```bash
+test -f skills/merge-prs/references/review-triage.md && echo "EXISTS"
+grep -c "reviewThreads" skills/merge-prs/references/review-triage.md
+grep -c "isResolved" skills/merge-prs/references/review-triage.md
+grep -c "in_reply_to" skills/merge-prs/references/review-triage.md
+```
+Expected: `EXISTS`, counts >= 1.
+
+Verify all 6 category names are present:
+```bash
+for cat in blocker suggestion nit question praise unclear; do
+  grep -q "\`$cat\`" skills/merge-prs/references/review-triage.md && echo "FOUND: $cat" || echo "MISSING: $cat"
+done
+```
+Expected: `FOUND:` for all 6.
+
+Verify section headers exist:
+```bash
+for section in "Overview" "Fetch Commands" "Thread Filtering Rules" "Classification Heuristics" "Fix Strategies Per Category" "Commit Grouping and Message Contract" "Reply Templates" "Mode Behavior" "wait_for_rereview" "Error Handling" "Reference Back to Shared File"; do
+  grep -q "## .*$section" skills/merge-prs/references/review-triage.md && echo "FOUND: $section" || echo "MISSING: $section"
+done
+```
+Expected: `FOUND:` for all sections (the heading marker may be `##` or `###`).
+
+**Step 4: Commit**
+
+```bash
+git add skills/merge-prs/references/review-triage.md
+git commit -m "feat: add review-triage reference with 6-category classification and fix strategies (#226)"
+```
+
+**Acceptance Criteria:**
+- [ ] File `skills/merge-prs/references/review-triage.md` exists
+- [ ] File second line begins with `Reference file for the \`merge-prs\` skill.`
+- [ ] File contains the string `best-effort-remediation.md` (reference back)
+- [ ] File contains the string `reviewThreads` (GraphQL fetch)
+- [ ] File contains the string `isResolved`
+- [ ] File contains the string `isOutdated`
+- [ ] File contains the string `in_reply_to`
+- [ ] File contains the string `databaseId`
+- [ ] File contains all 6 category names as backtick-wrapped literals: `blocker`, `suggestion`, `nit`, `question`, `praise`, `unclear`
+- [ ] File contains the string `MAX_ATTEMPTS:** 1` (single-pass distinct from ci-remediation)
+- [ ] File contains the string `fix: address review comment by`
+- [ ] File contains the string `fix: apply suggestion from`
+- [ ] File contains the string `wait_for_rereview`
+- [ ] File contains the string `Safety invariant` (mode behavior safety guarantee)
+- [ ] File contains all section headers: `Fetch Commands`, `Thread Filtering Rules`, `Classification Heuristics`, `Fix Strategies Per Category`, `Commit Grouping`, `Reply Templates`, `Mode Behavior`, `Error Handling`, `Reference Back to Shared File`
+
+---
+
+### Task 2: Update `SKILL.md` Step 4a — replace binary `CHANGES_REQUESTED` skip with triage flow
+
+**Files:**
+- Modify: `skills/merge-prs/SKILL.md` (line 89 in current file)
+
+**Step 1: Read the current line to confirm exact text**
+
+```bash
+sed -n '85,92p' skills/merge-prs/SKILL.md
+```
+
+Expected (line 89):
+```
+- If `reviews` has any `CHANGES_REQUESTED` state: flag to user, skip PR. Announce reason.
+```
+
+If the text differs, note the exact text — use it verbatim as `old_string` in the Edit call.
+
+**Step 2: Replace the line**
+
+Use the Edit tool on `skills/merge-prs/SKILL.md` with:
+
+`old_string`:
+```
+- If `reviews` has any `CHANGES_REQUESTED` state: flag to user, skip PR. Announce reason.
+```
+
+`new_string`:
+```
+- If any unresolved review threads, discussion comments, or formal reviews exist: enter single-pass review triage loop. Read `references/review-triage.md` and apply the triage flow (fetch all feedback surfaces in parallel, filter stale/resolved/self-reply threads, classify and fix, post replies). Review triage runs **before** the CI remediation loop so that any fix commits trigger a fresh CI run which `ci-remediation.md` can then handle. Skip the PR only if an unfixable blocker remains or (in YOLO) an unclear thread is found.
+```
+
+**Step 3: Verify the change**
+
+```bash
+grep -n "flag to user, skip PR. Announce reason" skills/merge-prs/SKILL.md
+```
+Expected: no output (old text is gone).
+
+```bash
+grep -n "references/review-triage.md" skills/merge-prs/SKILL.md
+```
+Expected: at least 1 match.
+
+```bash
+grep -n "single-pass review triage loop" skills/merge-prs/SKILL.md
+```
+Expected: at least 1 match.
+
+**Step 4: Commit**
+
+```bash
+git add skills/merge-prs/SKILL.md
+git commit -m "feat: replace binary CHANGES_REQUESTED skip with triage flow in SKILL.md Step 4a (#226)"
+```
+
+**Acceptance Criteria:**
+- [ ] `skills/merge-prs/SKILL.md` no longer contains the string `flag to user, skip PR. Announce reason`
+- [ ] `skills/merge-prs/SKILL.md` contains the string `references/review-triage.md`
+- [ ] `skills/merge-prs/SKILL.md` contains the string `single-pass review triage loop`
+- [ ] `skills/merge-prs/SKILL.md` contains the string `before** the CI remediation loop` (preserves ordering: triage before CI)
+
+---
+
+### Task 3: Update `SKILL.md` error recovery table row — `Unresolved review requests`
+
+**Files:**
+- Modify: `skills/merge-prs/SKILL.md` (approximately line 263 in current file)
+
+**Step 1: Read the current row to confirm exact text**
+
+```bash
+grep -n "Unresolved review requests" skills/merge-prs/SKILL.md
+```
+
+Expected: one match with text:
+```
+| Unresolved review requests | Skip with reason |
+```
+
+**Step 2: Replace the row**
+
+Use the Edit tool on `skills/merge-prs/SKILL.md` with:
+
+`old_string`:
+```
+| Unresolved review requests | Skip with reason |
+```
+
+`new_string`:
+```
+| Unresolved review requests | Enter single-pass review triage loop (see `references/review-triage.md`). Skip only if blockers cannot be fixed or (in YOLO) unclear threads remain. |
+```
+
+**Step 3: Verify the change**
+
+```bash
+grep -n "Unresolved review requests.*Skip with reason" skills/merge-prs/SKILL.md
+```
+Expected: no output (old row is gone).
+
+```bash
+grep -n "Unresolved review requests.*review-triage.md" skills/merge-prs/SKILL.md
+```
+Expected: exactly 1 match.
+
+**Step 4: Commit**
+
+```bash
+git add skills/merge-prs/SKILL.md
+git commit -m "fix: update error recovery row for unresolved review requests in SKILL.md (#226)"
+```
+
+**Acceptance Criteria:**
+- [ ] `skills/merge-prs/SKILL.md` does not contain the exact string `| Unresolved review requests | Skip with reason |`
+- [ ] `skills/merge-prs/SKILL.md` contains exactly one row starting with `| Unresolved review requests |`
+- [ ] That row contains the string `references/review-triage.md`
+- [ ] That row contains the string `single-pass review triage loop`
+
+---
+
+### Task 4: Update `.feature-flow.yml` — add `wait_for_rereview` comment field
+
+**Files:**
+- Modify: `.feature-flow.yml` (lines 24-33 in current file)
+
+**Step 1: Read the current comment block to confirm exact text**
+
+```bash
+sed -n '24,34p' .feature-flow.yml
+```
+
+Expected (approximately):
+```yaml
+# merge:                       # Optional: Ship phase merge configuration (all fields have defaults)
+# strategy: squash             # squash | merge | rebase (default: squash)
+# delete_branch: true          # delete branch after merge (default: true)
+# require_ci: true             # require CI green before merge (default: true)
+# require_review: true         # require approved review before merge (default: true)
+# auto_discover: label         # label | body_marker | both (default: label)
+# ci_remediation:                       # Bounded CI failure remediation loop (see skills/merge-prs/references/ci-remediation.md)
+#   max_attempts: 3                     # integer >= 1 (default: 3)
+#   max_wall_clock_minutes: 10          # integer >= 1 (default: 10)
+#   ci_poll_interval_seconds: 30        # integer >= 10 (default: 30; GitHub API rate-limit safe floor)
+```
+
+**Step 2: Insert the `wait_for_rereview` line**
+
+Insert `# wait_for_rereview: false     # Wait for re-approval after auto-fixing review comments (default: false; see skills/merge-prs/references/review-triage.md)` between the `# auto_discover: label` line and the `# ci_remediation:` line.
+
+Use the Edit tool with:
+
+`old_string`:
+```
+# auto_discover: label         # label | body_marker | both (default: label)
+# ci_remediation:                       # Bounded CI failure remediation loop (see skills/merge-prs/references/ci-remediation.md)
+```
+
+`new_string`:
+```
+# auto_discover: label         # label | body_marker | both (default: label)
+# wait_for_rereview: false     # Wait for re-approval after auto-fixing review comments (default: false; see skills/merge-prs/references/review-triage.md)
+# ci_remediation:                       # Bounded CI failure remediation loop (see skills/merge-prs/references/ci-remediation.md)
+```
+
+Make sure the leading `#` and spacing match the surrounding lines — keep the same alignment as other fields in the `merge:` block.
+
+**Step 3: Verify the change**
+
+```bash
+grep -n "wait_for_rereview" .feature-flow.yml
+```
+Expected: exactly 1 match.
+
+```bash
+grep -n "review-triage.md" .feature-flow.yml
+```
+Expected: exactly 1 match.
+
+Verify existing lines are unchanged:
+```bash
+grep -q "strategy: squash" .feature-flow.yml && echo "merge block intact" || echo "MISSING merge block"
+grep -q "ci_remediation" .feature-flow.yml && echo "ci_remediation intact" || echo "MISSING ci_remediation"
+```
+Expected: both print intact messages.
+
+**Step 4: Commit**
+
+```bash
+git add .feature-flow.yml
+git commit -m "feat: add wait_for_rereview config comment to .feature-flow.yml (#226)"
+```
+
+**Acceptance Criteria:**
+- [ ] `.feature-flow.yml` contains the string `wait_for_rereview: false`
+- [ ] `.feature-flow.yml` contains the string `skills/merge-prs/references/review-triage.md`
+- [ ] The `wait_for_rereview` line is hash-commented (starts with `#`)
+- [ ] Existing `strategy: squash` line still present
+- [ ] Existing `ci_remediation:` line still present
+- [ ] The `wait_for_rereview` line appears between `auto_discover` and `ci_remediation:` lines
+
+---
+
+### Task 5: Update `best-effort-remediation.md` — mark review triage as current consumer
+
+**Files:**
+- Modify: `skills/merge-prs/references/best-effort-remediation.md` (lines 11-14)
+
+**Step 1: Read the current "Current consumers" section**
+
+```bash
+sed -n '10,16p' skills/merge-prs/references/best-effort-remediation.md
+```
+
+Expected (approximately):
+```
+**Current consumers:**
+- `references/ci-remediation.md` (CI failure loop — issue #224)
+- `references/conflict-resolution.md` (merge conflict ladder — issue #225, future)
+- PR review triage (issue #226, future)
+```
+
+**Step 2: Replace the review triage line to mark it present**
+
+Use the Edit tool with:
+
+`old_string`:
+```
+- PR review triage (issue #226, future)
+```
+
+`new_string`:
+```
+- `references/review-triage.md` (PR review triage — issue #226)
+```
+
+**Step 3: Verify the change**
+
+```bash
+grep -n "PR review triage (issue #226, future)" skills/merge-prs/references/best-effort-remediation.md
+```
+Expected: no output (old line gone).
+
+```bash
+grep -n "references/review-triage.md" skills/merge-prs/references/best-effort-remediation.md
+```
+Expected: at least 1 match.
+
+**Step 4: Commit**
+
+```bash
+git add skills/merge-prs/references/best-effort-remediation.md
+git commit -m "docs: mark review triage as current consumer in best-effort-remediation.md (#226)"
+```
+
+**Acceptance Criteria:**
+- [ ] `skills/merge-prs/references/best-effort-remediation.md` does not contain the string `PR review triage (issue #226, future)`
+- [ ] `skills/merge-prs/references/best-effort-remediation.md` contains the string `references/review-triage.md`
+
+---
+
+## Summary Checklist
+
+After all 5 tasks are complete, verify every acceptance criterion passes. Each line should print `OK` (or `FOUND:` for category checks). Any missing or silent line = failed criterion, fix before declaring done.
+
+```bash
+# Task 1 — review-triage.md file
+test -f skills/merge-prs/references/review-triage.md && echo "T1 file OK"
+head -3 skills/merge-prs/references/review-triage.md | grep -q 'Reference file for the `merge-prs` skill' && echo "T1 header OK"
+grep -q "best-effort-remediation.md" skills/merge-prs/references/review-triage.md && echo "T1 shared-ref OK"
+grep -q "reviewThreads" skills/merge-prs/references/review-triage.md && echo "T1 reviewThreads OK"
+grep -q "isResolved" skills/merge-prs/references/review-triage.md && echo "T1 isResolved OK"
+grep -q "isOutdated" skills/merge-prs/references/review-triage.md && echo "T1 isOutdated OK"
+grep -q "in_reply_to" skills/merge-prs/references/review-triage.md && echo "T1 in_reply_to OK"
+grep -q "databaseId" skills/merge-prs/references/review-triage.md && echo "T1 databaseId OK"
+grep -q "wait_for_rereview" skills/merge-prs/references/review-triage.md && echo "T1 wait_for_rereview OK"
+grep -q "MAX_ATTEMPTS:\*\* 1" skills/merge-prs/references/review-triage.md && echo "T1 single-pass OK"
+grep -q "fix: address review comment by" skills/merge-prs/references/review-triage.md && echo "T1 commit-prefix OK"
+grep -q "Safety invariant" skills/merge-prs/references/review-triage.md && echo "T1 safety-invariant OK"
+for cat in blocker suggestion nit question praise unclear; do
+  grep -q "\`$cat\`" skills/merge-prs/references/review-triage.md && echo "T1 cat-$cat OK" || echo "T1 cat-$cat MISSING"
+done
+
+# Task 2 — SKILL.md Step 4a
+! grep -q "flag to user, skip PR. Announce reason" skills/merge-prs/SKILL.md && echo "T2 old-skip gone OK"
+grep -q "references/review-triage.md" skills/merge-prs/SKILL.md && echo "T2 new-ref OK"
+grep -q "single-pass review triage loop" skills/merge-prs/SKILL.md && echo "T2 loop-text OK"
+grep -q "before\*\* the CI remediation loop" skills/merge-prs/SKILL.md && echo "T2 ordering OK"
+
+# Task 3 — SKILL.md error recovery row
+! grep -q "| Unresolved review requests | Skip with reason |" skills/merge-prs/SKILL.md && echo "T3 old-row gone OK"
+grep -q "| Unresolved review requests |.*review-triage.md" skills/merge-prs/SKILL.md && echo "T3 new-row OK"
+
+# Task 4 — .feature-flow.yml
+grep -q "wait_for_rereview: false" .feature-flow.yml && echo "T4 wait_for_rereview OK"
+grep -q "skills/merge-prs/references/review-triage.md" .feature-flow.yml && echo "T4 ref OK"
+grep -q "strategy: squash" .feature-flow.yml && echo "T4 existing-merge-block OK"
+grep -q "ci_remediation" .feature-flow.yml && echo "T4 existing-ci-remediation OK"
+
+# Task 5 — best-effort-remediation.md consumers list
+! grep -q "PR review triage (issue #226, future)" skills/merge-prs/references/best-effort-remediation.md && echo "T5 old-future-marker gone OK"
+grep -q "references/review-triage.md" skills/merge-prs/references/best-effort-remediation.md && echo "T5 new-consumer OK"
+```
+
+Expected: every line prints `OK` (or `FOUND:` for category checks). If any line is silent or prints `MISSING`, that criterion has failed — fix the relevant task before declaring the implementation complete.

--- a/docs/plans/2026-04-08-merge-prs-review-triage.md
+++ b/docs/plans/2026-04-08-merge-prs-review-triage.md
@@ -1,0 +1,252 @@
+# PR Review & Comment Triage — Design Document
+
+**Date:** 2026-04-08
+**Status:** Draft
+**Issue:** #226
+**Scope:** feature
+**Depends on:** #224 (closed — `references/best-effort-remediation.md` already exists)
+
+## Overview
+
+Replace the current binary `CHANGES_REQUESTED` skip in `skills/merge-prs/SKILL.md:89` with a pre-merge triage step that fetches all three feedback surfaces (inline review comments, discussion comments, formal reviews), filters stale/resolved/self-reply threads, classifies each unresolved thread into one of six categories (question, nit, suggestion, blocker, praise, unclear), and makes a best-effort attempt to address each addressable thread — applying fixes, posting replies tied to fix commits, and skipping the PR only when a blocker cannot be fixed or an unclear thread remains. A new specialization file `references/review-triage.md` mirrors `references/ci-remediation.md` and imports the shared bounded-attempt pattern from `references/best-effort-remediation.md`.
+
+## Example
+
+**Input:** PR #N has three unresolved threads:
+1. Reviewer `@alice` on `src/api/handler.ts:42`: *"this will crash on empty input — needs a null check"* (inline, unresolved)
+2. Reviewer `@bob` on the PR discussion: *"nit: typo in the CHANGELOG entry — 'recieve' → 'receive'"* (discussion)
+3. Reviewer `@carol` on `src/utils/parse.ts:17`: a ` ```suggestion ` block replacing `str.split(',')` with `str.split(/,\s*/)` (inline, unresolved)
+
+**Output (YOLO mode):**
+
+```
+YOLO: ship — Review triage for PR #N (attempt 1/1, budget 00:00/10:00)
+  Threads fetched: 3 unresolved (0 filtered stale)
+  Classified: blocker(1), nit(1), suggestion(1)
+  → Applied: null check src/api/handler.ts:42 (blocker from @alice)
+  → Applied: CHANGELOG typo fix (nit from @bob)
+  → Applied: suggestion src/utils/parse.ts:17 (from @carol)
+  → Committed: fix: address review comments by @alice, @bob, @carol
+  → Pushed. Replied to 3 threads with fix commit sha abc1234.
+  → Re-review comment posted: @alice @bob @carol addressed 3 review comments in abc1234. Ready for re-review.
+  → Triage complete after 01:47. Proceeding to CI check.
+```
+
+## User Flow
+
+### Step 1 — Fetch all feedback surfaces
+
+Inside `SKILL.md` Step 4a (pre-merge checks), extend the existing parallel `gh` call block to also fetch:
+
+1. **GraphQL `reviewThreads`** via `gh api graphql` — single query that returns all threads with `id`, `isResolved`, `isOutdated`, `path`, `line`, `originalLine`, and nested `comments { id, databaseId, author { login }, body, createdAt, diffHunk, line, originalLine }`. This is the canonical fetch — REST `pulls/N/comments` does not expose `isResolved`.
+2. **Discussion comments** via `gh api repos/{owner}/{repo}/issues/{n}/comments` — flat list of general PR conversation comments (not anchored to files).
+3. **Current actor** via `gh api user --jq .login` — cached once per batch, used for the self-reply filter.
+
+The existing `gh pr view ... --json reviews` call already fetches formal review states; keep it.
+
+### Step 2 — Filter stale and irrelevant threads
+
+Apply four filters in order to every fetched thread:
+
+1. **Outdated** — `isOutdated == true` → drop.
+2. **Resolved** — `isResolved == true` → drop.
+3. **Self-reply** — any comment whose `author.login == <current_actor>` → drop the comment. If after dropping the thread has no non-self comments, drop the thread.
+4. **Addressed by later approval** — if the most recent review by a reviewer is `APPROVED` and its `submittedAt` is after the thread's last comment by that reviewer, drop the thread (assumed addressed).
+
+For discussion comments: apply filters 3 and 4 only (no `isOutdated`/`isResolved` concept).
+
+### Step 3 — Classify each unresolved thread
+
+Assign exactly one category per thread using priority-ordered heuristics. Priority order (top wins when multiple match):
+
+| Priority | Category | Detection pattern |
+|----------|----------|-------------------|
+| 1 | `blocker` | Comment contains `must`, `will crash`, `security`, `broken`, `blocker`, `vulnerability`, OR is anchored to a `CHANGES_REQUESTED` formal review |
+| 2 | `suggestion` | Comment body contains a ` ```suggestion ` fenced block |
+| 3 | `nit` | Comment starts with `nit:`, `style:`, `minor:`, or is purely about formatting (`indent`, `whitespace`, `semicolon`) |
+| 4 | `question` | Comment ends with `?` OR starts with `why`, `what`, `how`, `when`, `is this`, `should` (case-insensitive) |
+| 5 | `praise` | Comment body matches `lgtm`, `looks good`, `nice`, `approved`, `👍` (and nothing else substantive) |
+| 6 | `unclear` | None of the above — conservative fallback |
+
+A comment matching "nit: this will crash on empty input" wins under `blocker` — the safety keyword `crash` takes priority regardless of the `nit:` prefix.
+
+### Step 4 — Apply category-specific action
+
+For each classified thread, dispatch to the fix strategy for its category (see `references/review-triage.md § Fix Strategies Per Category`). Actions:
+
+- **question** — Generate a context-aware reply by reading the source file and answering. Post via `gh api ... -F in_reply_to=<comment_id>`.
+- **nit** — If the fix is obvious from the comment body (e.g., typo replacement, missing semicolon), apply via `Edit`. Reply `"Addressed in <sha>: <summary>"`.
+- **suggestion** — Parse the ` ```suggestion ` block, read the file at `line` (or `start_line..line` for multi-line), replace exactly, stage. Reply `"Applied suggestion in <sha>"`.
+- **blocker** — Read the source file and line, attempt a minimal targeted fix based on the comment intent. If the fix is ambiguous or patch fails, do NOT mark addressed. Reply only on successful fix.
+- **praise** — No reply, no action. Internal state marks thread "acknowledged".
+- **unclear** — Do not attempt. Record for mode-aware handling in Step 6.
+
+### Step 5 — Commit, push, reply
+
+Group applied fixes by `(reviewer, file)` tuple and create one commit per tuple with message `fix: address review comment by @<reviewer> on <file>:<line>` (or a multi-line body listing each thread when batching 2+ per commit). Push all commits. After push, post a reply to each addressed thread using `gh api ... -F in_reply_to=<comment_id> -f body="Addressed in <sha>. <summary>"`. If any blockers were fixed, post a single summary re-review comment via `gh pr comment N --body "@<reviewer1> @<reviewer2> addressed N review comments in latest commits: ..."`.
+
+### Step 6 — Handle unresolved and exit
+
+If any blocker thread could not be fixed OR any thread remains `unclear`:
+- **YOLO:** Skip PR with reason `N unresolved review threads: <summary>`.
+- **Express:** Pause via `AskUserQuestion` — options: "Address manually", "Skip PR", "Proceed anyway (override)".
+- **Interactive:** Pause via `AskUserQuestion` per thread.
+
+If all threads are addressed or benign (question/nit/suggestion/praise all handled):
+- **If `merge.wait_for_rereview: false` (default):** Exit triage, proceed to CI check immediately.
+- **If `merge.wait_for_rereview: true`:** Poll `gh pr view --json reviews` every 60s for up to 10 minutes waiting for APPROVED or CHANGES_REQUESTED state change. On APPROVED → proceed. On CHANGES_REQUESTED → skip PR. On timeout → proceed (trust the fix).
+
+## Mode Behavior
+
+| Mode | Questions | Nits / Suggestions | Blockers | Unclear |
+|------|-----------|--------------------|----------|---------|
+| **YOLO** | Auto-reply + announce | Auto-fix + reply + announce | Attempt fix; skip if unfixable | Skip PR |
+| **Express** | Confirm first reply per category, then auto | Confirm first fix per category, then auto | Confirm each fix | Pause via `AskUserQuestion` |
+| **Interactive** | Confirm each reply (show generated text) | Confirm each fix (show diff) | Confirm each fix (show diff) | Pause via `AskUserQuestion` |
+
+**Safety invariant (all modes):** A blocker that cannot be auto-fixed ALWAYS pauses or skips — never merged over. An `unclear` thread ALWAYS pauses in Express/Interactive and skips in YOLO.
+
+Announcement format (all modes — extends the shared template from `best-effort-remediation.md`):
+
+```
+<mode>: ship — Review triage for PR #<N> (attempt 1/1, budget <mm:ss>/10:00)
+  Threads fetched: <N> unresolved (<M> filtered stale)
+  Classified: <category>(<count>), ...
+  → <action taken per thread>
+  → <commit/push/reply result>
+  → <triage complete | skip reason>
+```
+
+## Shared Infrastructure
+
+### Reuse of `references/best-effort-remediation.md` (existing)
+
+Issue #224 already created this file. Review triage is the **second consumer** (after CI remediation) and uses the same sections:
+
+1. **Attempt loop skeleton** — parameterized with `MAX_ATTEMPTS=1`, `MAX_WALL_CLOCK=10min`. Single-pass: one classification + one batch of fixes per PR. No polling cycle (unlike CI which polls for test reruns).
+2. **Mode-aware escalation contract** — YOLO auto, Express confirm-first-then-auto, Interactive confirm-each. Already defined abstractly; review triage plugs in its own confirmation prompts.
+3. **Announcement format templates** — `<mode>: ship — <operation> for PR #<N> (attempt <k>/<MAX>, budget <mm:ss>/<MAX>)` with sub-bullets.
+4. **Decision table: skip vs pause vs escalate** — applies directly: blocker-unfixable → skip (YOLO) or pause (Express/Interactive); unclear → skip (YOLO) or pause; GitHub 5xx → retry once then skip.
+5. **Wall-clock tracking guidance** — start timestamp at triage entry, check before each `gh api` call.
+
+### `references/review-triage.md` (new, review-specific)
+
+Imports the shared pattern and specializes it for PR review handling. Sections (mirroring `ci-remediation.md` layout):
+
+1. **Overview** — Single-pass bounded triage: `MAX_ATTEMPTS=1`, `MAX_WALL_CLOCK=10min`, no polling. Reference back to `best-effort-remediation.md` for the skeleton.
+2. **Fetch commands** — the three parallel `gh` calls: GraphQL `reviewThreads` (with the full query text), REST `issues/N/comments`, cached `gh api user`. Includes exact GraphQL query string.
+3. **Thread filtering rules** — the four filters (outdated, resolved, self-reply, addressed-by-approval) with exact field references.
+4. **Classification heuristics table** — 6 rows ordered by priority: blocker, suggestion, nit, question, praise, unclear. Each row lists detection pattern and example comment snippet.
+5. **Fix strategies per category** — one table per category with: action description, GitHub API reply endpoint, commit behavior, example.
+6. **Suggestion block parser** — exact syntax for extracting ` ```suggestion ` fenced blocks from comment body; line-range handling for multi-line suggestions (using `start_line` field).
+7. **Reply templates** — canonical reply strings per category (with `<sha>`, `<summary>`, `<reviewer>` placeholders).
+8. **Commit message contract** — `fix: address review comment by @<reviewer> on <file>:<line>` (one-liner for single-thread commits) or multi-line body listing each thread when batching 2+.
+9. **Re-review comment template** — `@<reviewer> addressed N review comments in <sha>: [bullet list]. Ready for re-review.`
+10. **`wait_for_rereview` polling behavior** — when `merge.wait_for_rereview: true`, poll interval and exit conditions.
+11. **Reference back to shared file** — explicit "See `references/best-effort-remediation.md` for the attempt loop skeleton and mode escalation contract. This file specializes only the review-specific portions."
+
+## Patterns & Constraints
+
+### Error Handling
+
+- **`gh api` failures** (non-zero exit, network error, 5xx, rate limit): retry once after 5 seconds. If still failing, log and skip the thread — do not crash the triage. If GraphQL query fails entirely, skip the PR with reason `"review fetch failed"`.
+- **Patch apply failures** (suggestion block doesn't apply cleanly): retry once with relaxed context (3-way merge equivalent). If still failing, mark the thread unfixable and fall through to Step 6.
+- **Git push rejection** (non-fast-forward): fetch + rebase once, re-push. If still rejected, skip PR with reason.
+- **Self-reply loop prevention**: filter 3 (self-reply) is enforced BEFORE classification so merge-prs never sees its own past replies as new threads.
+- **Reply post failure**: if `gh api ... in_reply_to` fails, the commit is already pushed — log the failure but do NOT rollback. The fix stands; the reviewer will see the commit in the normal GitHub UI.
+- Project preference (`.feature-flow.yml design_preferences.error_handling: exceptions`): this is a prompt-instruction Markdown change — no executable code added.
+
+### Types (schema narrowness)
+
+- Category enum: closed literal set `blocker | suggestion | nit | question | praise | unclear` — not arbitrary strings.
+- `merge.wait_for_rereview`: boolean, default `false`.
+- Thread filter conditions are documented as boolean predicates against specific field names (`isOutdated`, `isResolved`, `author.login`, `submittedAt`) — no free-form text matching on thread metadata.
+- Comment classification uses regex/substring heuristics applied in priority order — the output is exactly one category label per thread.
+
+### Performance
+
+- Wall-clock budget enforced at triage entry and before each `gh api` call (fetch, reply, re-review comment).
+- Thread fetch uses a single GraphQL call to retrieve all review threads in one round-trip (vs. N REST calls for each thread).
+- Classification is purely local string matching — no network calls during the classification loop.
+- Fix application is sequential per thread (no parallelism across threads within one PR). Keeps git history clean and replies attributable.
+- Batch commit grouping (`reviewer + file` tuple) minimizes commit count while preserving attribution.
+- Re-review comment is a single `gh pr comment` call regardless of how many threads were addressed.
+
+### Stack-Specific
+
+- **Feature-flow skill file conventions** (from `references/ci-remediation.md`, `references/conflict-resolution.md`, `references/best-effort-remediation.md`):
+  - Reference files start with: *"Reference file for the `merge-prs` skill. Read this file when ..."*
+  - Tables use pipe syntax with a header-separator row.
+  - Announce formats are backtick-wrapped and prefixed with mode (`YOLO:`, `Express:`, `Interactive:`).
+  - Mode behavior uses a consistent column structure (YOLO | Express | Interactive).
+  - Specialization files end with a "Reference Back to Shared File" section.
+- **`.feature-flow.yml` comment style** (from existing `merge:` block at lines 24-29, ci_remediation block at lines 30-33): hash-comment block with `# field: value   # <type> (default: <value>)` format — `wait_for_rereview` must match this style.
+- **Commit messages**: `fix: address review comment by @<reviewer> on <file>:<line>` — conforms to conventional-commits. Note the **`fix:`** prefix (no scope suffix) to distinguish from `fix(ci):` used by ci-remediation.
+- **GraphQL query embedding**: multi-line heredoc style used by `gh api graphql -f query='...'` — the full query string will be quoted as a single argument in the reference file.
+
+## Files to Modify / Create
+
+### Create
+
+1. **`skills/merge-prs/references/review-triage.md`** — review-specific specialization of the shared bounded-attempt pattern. Sections: Overview, Fetch Commands (with GraphQL query), Thread Filtering Rules, Classification Heuristics, Fix Strategies Per Category, Suggestion Block Parser, Reply Templates, Commit Message Contract, Re-Review Comment Template, `wait_for_rereview` Polling, Reference Back to Shared File.
+
+### Modify
+
+2. **`skills/merge-prs/SKILL.md` Step 4a pre-merge checks block (lines 80-89)** — extend the existing `gh pr view` call with parallel fetches for GraphQL reviewThreads, discussion comments, and current actor. Replace line 89 (`CHANGES_REQUESTED` binary skip) with:
+   > If any unresolved review threads, discussion comments, or formal reviews exist: read `references/review-triage.md` and enter the single-pass triage flow. Review triage runs **before** the CI remediation loop so that any fix commits trigger a fresh CI run which `ci-remediation.md` can then handle. Skip the PR only if an unfixable blocker remains or (in YOLO) an unclear thread is found.
+
+3. **`skills/merge-prs/SKILL.md` error recovery table** (current line 263 `Unresolved review requests | Skip with reason`) — replace with:
+   > | Unresolved review requests | Enter bounded review triage loop (see `references/review-triage.md`). Skip only if blockers cannot be fixed or (in YOLO) unclear threads remain. |
+
+4. **`.feature-flow.yml` comment block (lines 24-33)** — extend the existing `merge:` commented-example block with a new `wait_for_rereview` field:
+
+   ```yaml
+   # merge:                       # Optional: Ship phase merge configuration (all fields have defaults)
+   # strategy: squash             # squash | merge | rebase (default: squash)
+   # delete_branch: true          # delete branch after merge (default: true)
+   # require_ci: true             # require CI green before merge (default: true)
+   # require_review: true         # require approved review before merge (default: true)
+   # auto_discover: label         # label | body_marker | both (default: label)
+   # wait_for_rereview: false     # Wait for re-approval after auto-fixing review comments (default: false; see references/review-triage.md)
+   # ci_remediation:                       # Bounded CI failure remediation loop (see skills/merge-prs/references/ci-remediation.md)
+   #   max_attempts: 3                     # integer >= 1 (default: 3)
+   #   max_wall_clock_minutes: 10          # integer >= 1 (default: 10)
+   #   ci_poll_interval_seconds: 30        # integer >= 10 (default: 30; GitHub API rate-limit safe floor)
+   ```
+
+## Scope
+
+### Included
+
+- Single-pass bounded triage loop (`MAX_ATTEMPTS=1`, `MAX_WALL_CLOCK=10min`, no polling cycle).
+- Three-surface fetch: GraphQL reviewThreads, REST issues/N/comments, cached current actor.
+- Four-stage thread filter: outdated, resolved, self-reply, addressed-by-approval.
+- Six classification categories with priority-ordered heuristics: blocker > suggestion > nit > question > praise > unclear.
+- Per-category fix strategies: generate reply (question), apply obvious fix (nit), parse+apply ` ```suggestion ` blocks (suggestion), attempt targeted fix (blocker), no-op (praise), escalate (unclear).
+- Commit message contract `fix: address review comment by @<reviewer> on <file>:<line>`.
+- Re-review comment with `@`-mentions summarizing addressed threads.
+- Mode-aware escalation: YOLO auto-fix-or-skip, Express confirm-first-per-category, Interactive confirm-each.
+- New optional config `merge.wait_for_rereview` (default `false`).
+- Integration into existing `SKILL.md` Step 4a **before** the CI remediation loop — review fixes trigger fresh CI which ci-remediation then handles.
+- Reuse of `references/best-effort-remediation.md` as the loop skeleton source (no modification).
+
+### Explicitly Excluded
+
+- **Sibling issue #225** (merge conflict ladder) — that continues to reference `best-effort-remediation.md` independently; this issue does not touch `conflict-resolution.md`.
+- **Formal review submission via `gh pr review`** — merge-prs does not submit reviews of its own; it only replies to existing threads and posts PR-level comments.
+- **Semantic code understanding for blocker fixes** — the fix strategy for blockers is minimal targeted patching based on the comment text and the anchored line. Complex refactors are out of scope → skip as unfixable.
+- **Thread resolution via GraphQL mutation** (`resolveReviewThread`) — merge-prs posts replies but does NOT mark threads resolved. Reviewers resolve threads themselves after verification. This is a deliberate choice: resolving on behalf of the reviewer removes their agency.
+- **Known-reviewer allowlists/blocklists** — every reviewer's feedback is triaged with the same logic regardless of identity.
+- **Custom reply templates in `.feature-flow.yml`** — reply templates are fixed in `review-triage.md`. User customization deferred to a future issue.
+- **Cross-PR deduplication** — if two PRs have the same reviewer leaving the same comment, each is triaged independently.
+- **Executable code changes** — pure prompt-instruction (Markdown + YAML comment) change. No Python, TypeScript, or test file is added.
+- **Implementation of the loop itself as a new tool** — the loop is executed by Claude following the Markdown instructions, not as a hook or sub-agent.
+- **Multi-attempt polling for CI-like retry** — review triage is a single-pass operation; unlike ci-remediation there is no "wait and re-check" loop.
+- **Batch LLM classification** — classification uses deterministic string matching, not an LLM call per thread (keeps triage fast and predictable).
+
+## Migration Requirements
+
+1. New optional YAML schema key `merge.wait_for_rereview` (boolean, default `false`). Existing `.feature-flow.yml` files without this block continue to work unchanged — no migration required.
+2. `skills/merge-prs/SKILL.md` gains one new reference-file dependency (`references/review-triage.md`). Any skill bundler or plugin packaging must include this file alongside `SKILL.md` and the existing `references/*.md` siblings.
+3. `skills/merge-prs/references/best-effort-remediation.md` "Current consumers" section should be updated to mark review triage as present (currently listed as "future").
+4. No database, no runtime config state, no Python/TS type changes.

--- a/skills/merge-prs/SKILL.md
+++ b/skills/merge-prs/SKILL.md
@@ -86,7 +86,7 @@ gh pr view <number> --json state,mergeable,statusCheckRollup,reviews
 - If `state: "MERGED"`: announce "PR #N already merged — skipping." Continue.
 - If `mergeable: "CONFLICTING"`: attempt conflict resolution (see §Conflict Resolution).
 - If CI failing: enter bounded remediation loop. Read `references/ci-remediation.md` and apply the attempt loop (default: 3 attempts, 10-min wall-clock, 30s poll interval). Skip only after budget exhausted or an `unknown` category is encountered.
-- If `reviews` has any `CHANGES_REQUESTED` state: flag to user, skip PR. Announce reason.
+- If any unresolved review threads, discussion comments, or formal reviews exist: enter single-pass review triage loop. Read `references/review-triage.md` and apply the triage flow (fetch all feedback surfaces in parallel, filter stale/resolved/self-reply threads, classify and fix, post replies). Review triage runs **before** the CI remediation loop so that any fix commits trigger a fresh CI run which `ci-remediation.md` can then handle. Skip the PR only if an unfixable blocker remains or (in YOLO) an unclear thread is found.
 
 **4b. Merge:**
 ```bash

--- a/skills/merge-prs/SKILL.md
+++ b/skills/merge-prs/SKILL.md
@@ -260,7 +260,7 @@ Strategy: continue-on-failure. Every skip is reported with a reason.
 | Merge conflict, auto-resolvable | Auto-resolve (trivial), announce, continue |
 | Merge conflict, behavioral | Pause for confirmation. If unresolved, skip with reason |
 | CI failing | Enter bounded remediation loop (see `references/ci-remediation.md`). Skip only after `MAX_ATTEMPTS` / `MAX_WALL_CLOCK` exhausted or `unknown` category detected. |
-| Unresolved review requests | Skip with reason |
+| Unresolved review requests | Enter single-pass review triage loop (see `references/review-triage.md`). Skip only if blockers cannot be fixed or (in YOLO) unclear threads remain. |
 | GitHub API error | Retry once after 5 seconds. If still failing, skip with reason |
 
 ---

--- a/skills/merge-prs/references/best-effort-remediation.md
+++ b/skills/merge-prs/references/best-effort-remediation.md
@@ -11,7 +11,7 @@ This file is the canonical definition of the **bounded-attempt pattern** used ac
 **Current consumers:**
 - `references/ci-remediation.md` (CI failure loop — issue #224)
 - `references/conflict-resolution.md` (merge conflict ladder — issue #225, future)
-- PR review triage (issue #226, future)
+- `references/review-triage.md` (PR review triage — issue #226)
 
 ---
 

--- a/skills/merge-prs/references/review-triage.md
+++ b/skills/merge-prs/references/review-triage.md
@@ -1,0 +1,279 @@
+# Review Triage
+
+Reference file for the `merge-prs` skill. Read this file when a PR has any unresolved inline review comments, discussion comments, or `CHANGES_REQUESTED` formal reviews — enter the single-pass triage flow described here.
+
+See `references/best-effort-remediation.md` for the attempt loop skeleton and mode escalation contract. This file specializes only the review-triage-specific portions.
+
+---
+
+## Overview
+
+When the pre-merge fetch in `SKILL.md` Step 4a returns any unresolved review threads or discussion comments, do not skip the PR without attempting remediation. Instead, enter the single-pass triage flow:
+
+- **MAX_ATTEMPTS:** 1 (review triage is atomic per PR — one classify + fix + reply pass)
+- **MAX_WALL_CLOCK:** 10 minutes (overridable — shares the same budget semantics as the shared skeleton)
+- **POLL_INTERVAL:** not applicable (no polling cycle; unlike ci-remediation there is no "wait for tests to rerun" step)
+
+Fetch all three feedback surfaces in parallel, filter stale/resolved/self-reply threads, classify each remaining thread into exactly one category, dispatch to the matching fix strategy, commit and push all fixes in per-(reviewer, file) groups, post replies tying each thread to its fix commit, and post a single re-review comment if any blockers were addressed.
+
+---
+
+## Fetch Commands
+
+Three parallel `gh` calls gather all feedback surfaces:
+
+**1. Review threads with resolution state (GraphQL — canonical):**
+
+```bash
+gh api graphql -F owner=<owner> -F name=<repo> -F number=<pr> -f query='
+  query($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            path
+            line
+            originalLine
+            startLine
+            comments(first: 50) {
+              nodes {
+                id
+                databaseId
+                author { login }
+                body
+                createdAt
+                diffHunk
+                line
+                originalLine
+                path
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+'
+```
+
+REST `repos/.../pulls/N/comments` does NOT expose `isResolved` or `isOutdated` — always use the GraphQL query above.
+
+**2. Discussion comments (REST — flat list, not anchored to files):**
+
+```bash
+gh api "repos/<owner>/<repo>/issues/<pr>/comments"
+```
+
+**3. Current actor (cached once per batch — used for self-reply filter):**
+
+```bash
+gh api user --jq .login
+```
+
+The existing `gh pr view ... --json reviews` call (already in Step 4a) continues to fetch formal review states. Keep it — do not remove it.
+
+---
+
+## Thread Filtering Rules
+
+Apply these four filters in order to every fetched thread. A thread that matches any filter is dropped from classification.
+
+| Filter | Condition | Applies To |
+|--------|-----------|------------|
+| **Outdated** | `isOutdated == true` in the GraphQL result | reviewThreads only (discussion comments have no `isOutdated` field) |
+| **Resolved** | `isResolved == true` in the GraphQL result | reviewThreads only |
+| **Self-reply** | All comments in the thread have `author.login == <current_actor>` — the current actor login is fetched once at Step 4a entry and cached for the batch | reviewThreads AND discussion comments |
+| **Addressed by later approval** | The most recent formal review by the thread's original commenter is `APPROVED` AND that review's `submittedAt` is after the thread's most recent comment by that reviewer | reviewThreads AND discussion comments |
+
+**Self-reply rule detail:** If a thread contains a mix of self-replies AND non-self comments, drop only the self-reply comments and keep the thread. If after dropping self-replies the thread has no remaining comments, drop the thread entirely. This prevents merge-prs from re-processing its own past fix replies as new feedback.
+
+**Stale line filter:** Any reviewThread whose `line` field is `null` in the GraphQL result is treated as outdated (the anchor line no longer exists in the current file) and dropped.
+
+---
+
+## Classification Heuristics
+
+Assign exactly one category per surviving thread. Apply rules top-to-bottom — **the first matching row wins**. Priority order is safety-first: a comment containing "crash" prefixed with "nit:" is still a `blocker`.
+
+| Priority | Category | Detection pattern | Example |
+|----------|----------|-------------------|---------|
+| 1 | `blocker` | Comment body (case-insensitive) contains any of: `must`, `will crash`, `security`, `broken`, `blocker`, `vulnerability`, `data loss`, `exploit` — OR the thread is anchored to a formal review with `state == "CHANGES_REQUESTED"` | `"this will crash on empty input — needs a null check"` |
+| 2 | `suggestion` | Comment body contains a ` ```suggestion ` fenced code block | Contains `` ```suggestion\nstr.split(/,\s*/)\n``` `` |
+| 3 | `nit` | Comment starts with (case-insensitive) `nit:`, `style:`, `minor:`, `typo:`, `small:` — OR is purely about formatting (`indent`, `whitespace`, `semicolon`, `trailing comma`) | `"nit: typo — 'recieve' → 'receive'"` |
+| 4 | `question` | Comment body ends with `?` OR starts with (case-insensitive) `why`, `what`, `how`, `when`, `is this`, `should`, `could` | `"why is this cast needed here?"` |
+| 5 | `praise` | Comment body (trimmed, case-insensitive) matches one of: `lgtm`, `looks good`, `nice`, `approved`, `👍`, `:+1:`, `ship it` — and contains nothing else substantive | `"lgtm 👍"` |
+| 6 | `unclear` | None of the above — conservative fallback | *(anything not matching rows 1-5)* |
+
+**Assignment rule:** Each surviving thread gets exactly one category. The priority order is fixed — a comment matching multiple patterns takes the highest-priority (lowest row number) match.
+
+---
+
+## Fix Strategies Per Category
+
+| Category | Action | GitHub API call | Commit behavior |
+|----------|--------|------------------|-----------------|
+| `blocker` | Read the source file and anchor line from `path` + `line`. Understand the comment intent. Apply a minimal targeted fix via `Edit`. If the fix is ambiguous, the patch fails to apply, or the intent cannot be determined from the comment + code context alone, mark the thread **unfixable** and fall through to mode-aware escalation. Do not refactor beyond the exact concern raised. | `POST repos/{owner}/{repo}/pulls/{pr}/comments` with `-F in_reply_to=<databaseId>` and `-f body="Addressed in <sha>. <summary>"` | Commit with `fix: address review comment by @<reviewer> on <file>:<line>` |
+| `suggestion` | Parse the ` ```suggestion ` fenced block from comment body (may be single-line or multi-line). Read the file at `line` (single-line) or `startLine..line` (multi-line). Replace exactly. If patch apply fails, retry once with 3-way merge semantics. If still failing, mark unfixable. | Same as blocker (`in_reply_to` on the inline comment) with body `"Applied suggestion in <sha>"` | Commit with `fix: apply suggestion from @<reviewer> on <file>:<line>` |
+| `nit` | If the fix is obvious from the comment body (e.g., typo replacement with explicit before/after, missing semicolon, obvious formatting), apply via `Edit`. If the fix is not obvious from the comment body alone, mark unfixable and fall through. Do NOT guess. | Same as blocker (`in_reply_to` on the inline comment) with body `"Addressed in <sha>: <summary>"` | Commit with `fix: address nit from @<reviewer> on <file>:<line>` |
+| `question` | Read the source file at the anchor line (if inline) or read the PR summary/relevant files (if discussion). Generate a context-aware answer based on the code. Post as reply — no code change, no commit. | For inline: `POST repos/{owner}/{repo}/pulls/{pr}/comments` with `in_reply_to=<databaseId>`. For discussion: `gh pr comment <pr> --body "<answer>"`. | No commit (reply-only) |
+| `praise` | No action. No reply. Record internally as "acknowledged". Does not block merge. | None | None |
+| `unclear` | Do not attempt to auto-resolve. Fall through to mode-aware escalation in Step 6. | None | None |
+
+**Suggestion block parser:** Extract content between ` ```suggestion ` and ` ``` ` fences. Multi-line suggestions are delimited by `start_line` (first line to replace) and `line` (last line to replace) fields in the GraphQL result. Single-line suggestions use `line` only.
+
+**Reply endpoint selection:**
+- Inline review thread (has `path` and `line`): `POST repos/{owner}/{repo}/pulls/{pr}/comments` with `in_reply_to=<databaseId>` (integer — use `-F` not `-f`)
+- Discussion comment (no `path`): `gh pr comment <pr> --body "..."` (PR-level comment)
+- Formal review ack (when replying to a review body, not an inline comment): `gh pr review <pr> --comment --body "..."`
+
+**Identifier rule:** When calling `in_reply_to`, use the integer `databaseId` field from the GraphQL comment node — NOT the string `id` (GraphQL global node ID). The REST reply endpoint requires the integer database ID.
+
+---
+
+## Commit Grouping and Message Contract
+
+**Grouping rule:** Group applied fixes by `(reviewer, file)` tuple. One commit per tuple. This keeps git log attributable per reviewer and per touched file.
+
+**Single-thread commit format:**
+```
+fix: address review comment by @<reviewer> on <file>:<line>
+```
+
+**Multi-thread commit format (2+ threads in same (reviewer, file) group):**
+```
+fix: address review comments by @<reviewer>
+
+- <file>:<line> — <brief summary of fix>
+- <file>:<line> — <brief summary of fix>
+```
+
+**Rule:** Use the `fix:` prefix (no scope suffix) to distinguish from `fix(ci):` used by ci-remediation. The `fix:` prefix alone signals "review feedback addressed".
+
+**Examples:**
+```
+fix: address review comment by @alice on src/api/handler.ts:42
+```
+
+```
+fix: apply suggestion from @carol on src/utils/parse.ts:17
+```
+
+```
+fix: address review comments by @alice
+
+- src/api/handler.ts:42 — added null check for empty input
+- src/api/handler.ts:58 — added error return path for parse failure
+```
+
+---
+
+## Reply Templates
+
+Use these exact templates. Replace placeholders in `<angle brackets>`.
+
+**Fix applied (blocker, suggestion, nit — inline reply via `in_reply_to`):**
+```
+Addressed in <sha>. <one-line summary of what was changed>
+```
+
+**Suggestion applied (specialization of above):**
+```
+Applied suggestion in <sha>.
+```
+
+**Question answer (context-aware — generated from code; no fixed template):**
+Generate a concise, factual answer based on reading the anchored file and line. Keep it under 3 sentences. Do not speculate — if the answer isn't clear from the code, classify as `unclear` instead.
+
+**Praise (no reply posted — internal acknowledgement only):**
+*(none)*
+
+**Re-review summary comment (posted once per PR if any blockers were addressed):**
+
+```bash
+gh pr comment <pr> --body "@<reviewer1> @<reviewer2> addressed N review comments in latest commits:
+- <file>:<line> — <brief fix summary>
+- <file>:<line> — <brief fix summary>
+
+Ready for re-review."
+```
+
+The reviewers in the `@mention` list are the union of all reviewers whose blocker threads were addressed. Do NOT `@`-mention reviewers whose only contributions were praise, addressed-question replies, or addressed-nit replies — those are already handled by the inline thread replies.
+
+---
+
+## Mode Behavior
+
+See `references/best-effort-remediation.md § Mode-Aware Escalation Contract` for the base contract. Review-triage specifics:
+
+| Mode | Questions | Nits / Suggestions | Blockers | Unclear |
+|------|-----------|--------------------|----------|---------|
+| **YOLO** | Auto-generate reply + announce | Auto-fix + reply + announce | Attempt fix; if unfixable → skip PR | Skip PR (reason: `N unclear review threads require manual triage`) |
+| **Express** | Confirm first reply per category via `AskUserQuestion` (show generated text), then auto for rest | Confirm first fix per category (show diff), then auto for rest | Confirm each fix via `AskUserQuestion` (show diff) | Pause via `AskUserQuestion` — options: "Address manually", "Skip PR", "Proceed anyway (override)" |
+| **Interactive** | Confirm each reply (show generated text per thread) | Confirm each fix (show diff per thread) | Confirm each fix (show diff per thread) | Pause via `AskUserQuestion` per thread |
+
+**Safety invariant (all modes):** A blocker that cannot be auto-fixed ALWAYS pauses (Express/Interactive) or skips (YOLO) — it is NEVER merged over. An `unclear` thread ALWAYS pauses (Express/Interactive) or skips (YOLO).
+
+---
+
+## `wait_for_rereview` Polling Behavior
+
+Read `.feature-flow.yml` `merge.wait_for_rereview` (default: `false`).
+
+**When `false` (default):** After posting fix replies and the re-review comment, proceed immediately to the CI check step. Do not wait for the reviewer to respond. Trust the fix.
+
+**When `true`:** After posting the re-review comment, poll `gh pr view <pr> --json reviews --jq '.reviews[-1]'` every 60 seconds for up to 10 minutes or until the MAX_WALL_CLOCK budget is exhausted:
+
+- If a new review appears with `state == "APPROVED"` → proceed to CI check.
+- If a new review appears with `state == "CHANGES_REQUESTED"` → skip PR with reason `re-review requested changes after auto-fix`.
+- If 10 minutes elapse with no new review → proceed to CI check (timeout-trust).
+
+---
+
+## Re-Review Comment Template
+
+When any blocker threads have been successfully addressed, post a single summary comment at the end of the triage flow (after all inline replies):
+
+```bash
+gh pr comment <pr> --body "$(cat <<EOF
+@<reviewer1> @<reviewer2> addressed <N> review comments in the latest commits:
+
+- <file1>:<line1> — <brief summary>
+- <file2>:<line2> — <brief summary>
+
+Ready for re-review.
+EOF
+)"
+```
+
+Do NOT post a re-review comment if only nits/suggestions/questions were addressed — inline replies suffice for those. The re-review comment exists specifically to notify reviewers that safety-critical feedback was acted on.
+
+---
+
+## Error Handling
+
+- **`gh api` failures** (non-zero exit, network error, 5xx, rate limit): retry once after 5 seconds. If still failing, log and skip the thread — do not crash the triage. If the initial GraphQL fetch fails entirely, skip the PR with reason `"review fetch failed"`.
+- **Patch apply failures** (suggestion block or blocker fix doesn't apply cleanly): retry once with relaxed context (3-way merge equivalent). If still failing, mark the thread unfixable and fall through to mode-aware escalation.
+- **Git push rejection** (non-fast-forward): fetch + rebase once, re-push. If still rejected, skip PR with reason `push rejected after rebase`.
+- **Reply post failure**: if `gh api ... -F in_reply_to=<id>` fails after the retry, the commit is already pushed — log the failure but do NOT rollback. The fix stands; the reviewer will see the commit in the GitHub UI.
+- **Self-reply loop prevention**: filter 3 (self-reply) is enforced BEFORE classification so merge-prs never sees its own past replies as new threads. This is mandatory — skipping this filter causes infinite loops when merge-prs is the PR author.
+
+---
+
+## Reference Back to Shared File
+
+This file specializes the loop defined in `references/best-effort-remediation.md`:
+
+- **Attempt loop skeleton** → `best-effort-remediation.md § Attempt Loop Skeleton` (with `MAX_ATTEMPTS=1`)
+- **Mode-aware escalation** → `best-effort-remediation.md § Mode-Aware Escalation Contract`
+- **Announcement templates** → `best-effort-remediation.md § Announcement Format Templates`
+- **Skip/pause/escalate decisions** → `best-effort-remediation.md § Decision Table`
+- **Wall-clock tracking** → `best-effort-remediation.md § Wall-Clock Tracking Guidance`
+
+Review-triage-specific parameters:
+- `detect_failures()` → Fetch Commands + Thread Filtering Rules + Classification Heuristics (above)
+- `apply_fix(thread)` → Fix Strategies Per Category (above)
+- `verify_success()` → not applicable (single-pass; optional `wait_for_rereview` polling instead)
+- `build_commit_message()` → Commit Grouping and Message Contract (above)


### PR DESCRIPTION
## Summary

Replace the binary `CHANGES_REQUESTED` skip in `skills/merge-prs/SKILL.md:89` with a single-pass triage flow that fetches inline review comments, discussion comments, and formal reviews; filters stale/resolved/self-reply threads; classifies each remaining thread into one of 6 categories (blocker/suggestion/nit/question/praise/unclear); attempts best-effort remediation; and replies with fix commit attribution.

Closes #226.

## Design

See [`docs/plans/2026-04-08-merge-prs-review-triage.md`](docs/plans/2026-04-08-merge-prs-review-triage.md) for the full design.

**Key decisions:**

- **Single-pass bounded loop** (`MAX_ATTEMPTS=1`, `MAX_WALL_CLOCK=10min`) — unlike `ci-remediation`'s multi-attempt polling, review triage is atomic per PR: classify + fix + reply once.
- **GraphQL `reviewThreads`** is the canonical fetch — REST `pulls/N/comments` does not expose `isResolved`/`isOutdated` state.
- **Classification priority order** `blocker > suggestion > nit > question > praise > unclear` — a comment with "crash" prefixed "nit:" is still a blocker (safety-first).
- **Four-stage thread filter:** outdated, resolved, self-reply (prevents merge-prs from replying to its own past fixes), addressed-by-later-approval.
- **Runs BEFORE `ci-remediation`** in Step 4a so review fixes trigger a fresh CI run that `ci-remediation` then handles.
- **Commit prefix `fix:`** (not `fix(ci):`) to distinguish from CI remediation commits.
- **Reuses** existing `references/best-effort-remediation.md` from #224 — no modification to the shared pattern.
- **Mode behavior:** YOLO auto-fix-or-skip, Express confirm-first-per-category, Interactive confirm-each. **Safety invariant:** an unfixable blocker never gets merged over.

**Depends on #224** (closed) — provides `skills/merge-prs/references/best-effort-remediation.md`.

## Files Changed

| File | Change |
|------|--------|
| `skills/merge-prs/references/review-triage.md` | **New** — 279 lines. Specialization of `best-effort-remediation.md` with 6-category classification, per-category fix strategies, reply templates, commit message contract, `wait_for_rereview` polling, error handling. |
| `skills/merge-prs/SKILL.md` Step 4a (line 89) | **Modified** — replace binary `CHANGES_REQUESTED` skip with triage flow routing. |
| `skills/merge-prs/SKILL.md` error recovery table (line 263) | **Modified** — replace `Unresolved review requests → Skip with reason` with triage loop entry point. |
| `.feature-flow.yml` | **Modified** — add `merge.wait_for_rereview` comment field (default `false`). |
| `skills/merge-prs/references/best-effort-remediation.md` | **Modified** — mark review triage as a current consumer (previously listed as "future"). |
| `.changelogs/226-review-triage.md` | **New** — changelog fragment. |

## Test Plan

- [x] All 43 acceptance criteria from `docs/plans/2026-04-08-merge-prs-review-triage-implementation.md` verified via `verify-acceptance-criteria` — 43/43 PASS
- [x] Section structure matches sibling `ci-remediation.md` (Overview → Fetch → Filter → Classify → Fix → Commit → Reply → Mode → Polling → Error → Reference Back)
- [x] All file cross-references resolve (`references/best-effort-remediation.md` exists)
- [x] Markdown fence balance verified (24 fences = 12 pairs)
- [x] Table pipe counts consistent per table (3-col filter, 4-col classification/fix, 5-col mode behavior)
- [x] Integration points in `SKILL.md` verified at line 89 (Step 4a) and line 263 (error recovery)
- [x] `.feature-flow.yml` `wait_for_rereview` line placed correctly between `auto_discover` and `ci_remediation:`
- [ ] **Manual verification:** run `merge-prs` on a test PR with inline comments to exercise the classification/fix paths end-to-end
- [ ] **Manual verification:** confirm the GraphQL `reviewThreads` query returns expected fields on a live PR

## Notes

- This is a **prompt-instruction-only change** — no runtime code, no tests, no schema. All changes are Markdown + YAML comment documents consumed by Claude at runtime when the `merge-prs` skill is invoked.
- Sibling issue #225 (merge conflict ladder) is independent and does not touch these files.
- The session-local `.feature-flow/` and `FEATURE_CONTEXT.md` files are gitignored-but-already-tracked (a pre-existing bug in the repo). Intentionally NOT modified in this PR to keep the diff focused.