### PR TITLE
refactor(settings): remove redundant Setting Definitions Reference table

### DIFF
--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -634,23 +634,6 @@ Do not exit the skill after a save. The user exits explicitly by selecting "Done
 
 ---
 
-## Setting Definitions Reference
-
-| # | Setting | YAML Path | Default |
-|---|---------|-----------|---------|
-| 1 | YOLO stops | `yolo.stop_after` | `[]` (no stops) |
-| 2 | Notifications | `notifications.on_stop` | `bell` |
-| 3 | Default branch | `default_branch` | _(absent = auto-detect)_ |
-| 4 | Git strategy | `git_strategy` | `merge` |
-| 5 | Design preferences | `design_preferences.*` | _(absent = infer from codebase)_ |
-| 6 | Tool selector | `tool_selector.*` | enabled, 0.7, no auto-launch |
-| 7 | Context7 libraries | `context7.*` | _(absent = no mappings)_ |
-| 8 | CI timeout | `ci_timeout_seconds` | `900` |
-| 9 | KB limits | `knowledge_base.max_lines`, `knowledge_base.stale_days` | `150`, `14` |
-| 10 | Standards | `standards.*` | _(absent = auto-discovery on next design-document run)_ |
-
----
-
 ## Special Cases
 
 ### Notification Hook Side Effect

--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -91,7 +91,7 @@ tool_selector:
 
 Then announce: "Created `.feature-flow.yml` with defaults. You can now configure your settings."
 
-**If the file exists**, read it and parse the current values for all 10 settings using the reference table below.
+**If the file exists**, read it and parse the current values for all 10 settings.
 
 ### Step 2: Display Dashboard
 


### PR DESCRIPTION
## Summary

- Deletes the 10-row `Setting Definitions Reference` table (former lines 637–652 of `skills/settings/SKILL.md`)
- Every YAML path and default in that table is already fully specified in the Step 5 per-setting sections (5A–5H) — the table was pure duplication
- No behavior change, no content loss

## Test plan

- [ ] Open `/settings`, browse settings categories — all Step 5 sections still load correctly
- [ ] Confirm `grep -n "Setting Definitions Reference" skills/settings/SKILL.md` returns no results

Closes #250 (table-deletion portion — the quick win identified in the reviewer comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)