### PR TITLE
feat(start): convert design-document to Pattern B subagent dispatch (#251)

### DIFF
--- a/.changelogs/2026-05-02-design-document-pattern-b-conversion.md
+++ b/.changelogs/2026-05-02-design-document-pattern-b-conversion.md
@@ -1,0 +1,18 @@
+---
+date: 2026-05-02
+scope: feature
+issue: 251
+---
+
+### Changed
+- `feature-flow:design-document` is now invoked via Pattern B subagent dispatch (orchestrator-side parallel Explore fanout with `model: "haiku"` + consolidator subagent with `model: "sonnet"`) per #251. The orchestrator never sees the consolidator's intermediate design-writing work — only a structured return contract validated against `hooks/scripts/validate-return-contract.js`. Replaces the pre-#251 YOLO `Task()` wrapper at `skills/start/SKILL.md:~688` (latently broken: subagents cannot dispatch sub-subagents per #251 Q1 spike, so the inner Explore fanout silently failed).
+
+### Added
+- New "Design Document — Pattern B Dispatch" section in `skills/start/SKILL.md` documents the full hoist + consolidator dispatch shape, post-dispatch validation sequence, and 4-case inline-fallback table (rollout-only with explicit sunset).
+- New `findings_path`, `write_contract_to`, and `phase_id` optional args in `skills/design-document/SKILL.md` enable consolidator-mode invocation. New Step 8 contract-write helper mirrors `skills/verify-plan-criteria/SKILL.md` Step 7.
+- `design-document` schema entry added to `hooks/scripts/validate-return-contract.js` (9 required fields per #251 locked contract). 7 new unit tests (15 total pass), new fixture `hooks/scripts/fixtures/valid-design-document.json`, and Pattern B round-trip in `hooks/scripts/validate-return-contract.e2e.sh`.
+
+### Documentation
+- CRITICAL routing block in `skills/start/SKILL.md:683` updated: design-document moved from "Future conversions" to "Currently converted" alongside verify-plan-criteria. merge-prs documented as "Skipped by design analysis" (no orchestrator-side benefit; see #251 comment).
+- Skill Mapping table row for "Design document" updated to reference the Pattern B wrapper.
+- Design phase boundary write note updated to clarify return_contract preservation when Pattern B writes the contract before the boundary write.

--- a/docs/plans/2026-05-02-design-document-pattern-b-conversion.md
+++ b/docs/plans/2026-05-02-design-document-pattern-b-conversion.md
@@ -350,7 +350,7 @@
 
   ```markdown
   **`findings_path` short-circuit (Pattern B only):** If `findings_path` is present in ARGUMENTS, the orchestrator has already dispatched the parallel Explore agents and written their results to a JSON file at that path. In this case:
-  1. Read the JSON file at `findings_path`. It contains an array of `{area: string, findings: string[]}` objects.
+  1. Read the JSON file at `findings_path`. It contains a single object `{"agents": [{"area": string, "findings": string[]}, ...]}` — the `agents` array is the list of Explore returns; iterate over it.
   2. Use these as the agent findings for the Consolidation block below — skip the agent dispatch entirely.
   3. Jump directly to **Consolidation** (do not dispatch Task agents, do not announce parallel dispatch).
 
@@ -900,6 +900,6 @@
 
 1. **#253 measurement tooling availability:** Is the per-phase instrumentation from issue #253 deployed? If not, Task 7 must use a proxy estimate. The plan assumes proxy is acceptable but the decision rule (≥5%) still applies. If proxy cannot be computed, Task 7 becomes a manual judgment call — surface to user before proceeding.
 
-2. **`findings_path` JSON leniency:** The Explore agent return format is `{area: string, findings: string[]}` per `skills/design-document/SKILL.md:46-49`. The format is controlled by the orchestrator's own dispatch prompt so drift is unlikely, but if a real session fails on malformed findings JSON, the `findings_path` branch in Step 1 should use lenient parsing (extract `area` + `findings` keys, ignore extras) rather than strict shape validation.
+2. **`findings_path` JSON leniency:** The findings file at `findings_path` contains a top-level object `{"agents": [{"area": string, "findings": string[]}, ...]}`. Each `agents[]` entry mirrors the Explore-agent return format documented at `skills/design-document/SKILL.md:46-49`. The wrapping `{"agents": [...]}` shape is set by the orchestrator's findings-write helper in `skills/start/SKILL.md` "Design Document — Pattern B Dispatch" sub-step 2. The format is controlled by the orchestrator's own dispatch prompt so drift is unlikely, but if a real session fails on malformed findings JSON, the `findings_path` branch in Step 1 should use lenient parsing (extract `area` + `findings` keys per agent entry, ignore extras) rather than strict shape validation.
 
 </plan>

--- a/docs/plans/2026-05-02-design-document-pattern-b-conversion.md
+++ b/docs/plans/2026-05-02-design-document-pattern-b-conversion.md
@@ -1,0 +1,905 @@
+<plan version="1.1">
+# design-document Pattern B Conversion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert `feature-flow:design-document` from an inline Skill() call to a Pattern B subagent dispatch (orchestrator-owned Explore fanout + consolidator subagent), matching the Pattern A wrapper structure already deployed for `verify-plan-criteria` in PR #262.
+
+**Architecture:** The orchestrator dispatches 3-4 Haiku Explore agents in parallel (hoisted from `skills/design-document/SKILL.md` Step 1), then dispatches a single Sonnet consolidator subagent that invokes `feature-flow:design-document` with a pre-populated `findings_path` arg (skipping the now-hoisted fanout). The skill writes a structured return contract to `phase_summaries.design.return_contract` in the in-progress state file. The validator (`hooks/scripts/validate-return-contract.js`) gains a `design-document` SCHEMAS entry. An inline-fallback (rollout-only) mirrors the `verify-plan-criteria` pattern.
+
+**Tech Stack:** Node.js (validator + tests), Python3 + PyYAML (state-file helpers), Bash (e2e test), Markdown (SKILL.md edits)
+
+**Reference files:**
+- `skills/verify-plan-criteria/SKILL.md` (Step 7 contract-write helper — mirror for Task 3)
+- `skills/start/SKILL.md:697-751` (Pattern A wrapper — structural template for Task 4)
+- `hooks/scripts/validate-return-contract.js` (extend SCHEMAS in Task 2)
+- `hooks/scripts/validate-return-contract.test.js` (extend tests in Task 2)
+- `hooks/scripts/validate-return-contract.e2e.sh` (extend e2e in Task 6)
+- `hooks/scripts/fixtures/valid-verify-plan-criteria.json` (fixture template for Task 2)
+
+---
+
+<task id="1" status="pending">
+### Task 1: Lock design-document return contract on issue #251
+
+**Files:**
+- No code files modified. Manual-only task.
+
+**Context:** The design-document return contract is specified in `.feature-flow/design/design-decisions.md`. It must be posted as a comment on issue #251 before any code lands — locking the contract prevents schema drift across the PR.
+
+**Acceptance criteria:**
+- [ ] `[MANUAL]` GitHub comment URL exists on issue #251 containing the design-document JSON Schema block — measured by: `gh issue view 251 --comments --json comments --jq '.comments[].body' | grep -c '"design-document"'` outputs `>= 1`
+
+**Steps:**
+
+- [ ] **Step 1: Post the locked contract as a comment on #251**
+
+  Run:
+  ```bash
+  gh issue comment 251 --body "$(cat <<'EOF'
+  ## design-document return contract (locked for Pattern B implementation)
+
+  Per the Pattern B conversion plan (Wave 3 phase 3), the `design-document` phase return contract is locked at schema_version 1:
+
+  ```json
+  {
+    "schema_version": 1,
+    "phase": "design-document",
+    "status": "success | partial | failed",
+    "design_issue_url": "string (URL of issue containing design)",
+    "issue_number": "integer",
+    "design_section_present": "boolean (true if <!-- feature-flow:design:start --> markers present in issue body)",
+    "key_decisions": ["array of decision strings, max 5"],
+    "open_questions": ["array of unresolved question strings, empty if none"],
+    "tbd_count": "integer (count of [TBD] markers in design body)"
+  }
+  ```
+
+  **Phase/bucket distinction (critical — bit PR #262):**
+  - `phase_id: design` — the `phase_summaries` bucket key in the in-progress state file
+  - `phase: "design-document"` — the contract's own `phase` field (lifecycle step name, used by validator to look up schema)
+  These are two distinct concepts. The bucket key is `design`; the step name is `design-document`.
+
+  **schema_version:** `1` (contract schema version — independent of state-file schema_version which is `2`).
+  EOF
+  )"
+  ```
+
+  Expected output: a GitHub comment URL like `https://github.com/uta2000/feature-flow/issues/251#issuecomment-...`
+
+- [ ] **Step 2: Capture and record the comment URL**
+
+  Run:
+  ```bash
+  gh issue view 251 --comments --json comments --jq '.comments[-1].url'
+  ```
+
+  Record the URL in session notes. This is the acceptance criterion anchor for `[MANUAL]` verification.
+</task>
+
+<task id="2" status="pending">
+### Task 2: Extend validator with design-document schema + fixtures + unit tests
+
+**Files:**
+- Modify: `hooks/scripts/validate-return-contract.js` (SCHEMAS object — add `design-document` entry)
+- Modify: `hooks/scripts/validate-return-contract.test.js` (add design-document test cases)
+- Create: `hooks/scripts/fixtures/valid-design-document.json`
+
+**Quality Constraints:**
+- Error handling: existing fail-closed pattern (any unexpected error exits 1) — do NOT change the outer `try/catch` in `main()`; only add to `SCHEMAS` and extend tests.
+- Function length: `validate()` and `checkField()` are both under 30 lines and must stay under 30 lines after this change — adding a SCHEMAS entry does not touch function bodies.
+- Pattern reference: match `verify-plan-criteria` entry at `hooks/scripts/validate-return-contract.js:7-16` exactly (field names, type strings).
+
+**CRITICAL — phase/bucket confusion:**
+- The `SCHEMAS` key MUST be `'design-document'` (the lifecycle step name / contract `phase` field value — what the validator uses for lookup).
+- The state-file bucket key (`phase_id: design`) is NEVER used as a SCHEMAS key.
+- In the test fixture, `"phase": "design-document"` — NOT `"phase": "design"`.
+- Add an inline comment in the SCHEMAS entry: `// bucket key = 'design' (phase_summaries); step name = 'design-document' (contract phase field)`
+
+**Acceptance criteria:**
+- [ ] `node hooks/scripts/validate-return-contract.js hooks/scripts/fixtures/valid-design-document.json` exits 0 — measured by: `echo $?` outputs `0`
+- [ ] `node hooks/scripts/validate-return-contract.test.js` exits 0 and all design-document tests PASS — measured by: `node hooks/scripts/validate-return-contract.test.js | grep -E "^Results:"` outputs `Results: N passed, 0 failed` with N >= 15 (8 existing + 7 new)
+- [ ] `node hooks/scripts/validate-return-contract.js /tmp/bad-design-document.json` exits 1 for a contract with a missing required field — measured by: create `{"schema_version":1,"phase":"design-document","status":"success"}` at `/tmp/bad-design-document.json`, run validator, `echo $?` outputs `1`
+
+**Steps:**
+
+- [ ] **Step 1: Add `design-document` entry to SCHEMAS**
+
+  Read `hooks/scripts/validate-return-contract.js` lines 6-17 first. Then edit:
+
+  In `hooks/scripts/validate-return-contract.js`, replace the SCHEMAS object:
+  ```js
+  const SCHEMAS = {
+    'verify-plan-criteria': {
+      schema_version: 'number',
+      phase: 'string',
+      status: 'string',
+      plan_path: 'string',
+      criteria_total: 'number',
+      criteria_machine_verifiable: 'number',
+      criteria_added_by_agent: 'number',
+      tasks_missing_criteria: 'array',
+    },
+    // bucket key = 'design' (phase_summaries); step name = 'design-document' (contract phase field)
+    'design-document': {
+      schema_version: 'number',
+      phase: 'string',
+      status: 'string',
+      design_issue_url: 'string',
+      issue_number: 'number',
+      design_section_present: 'boolean',
+      key_decisions: 'array',
+      open_questions: 'array',
+      tbd_count: 'number',
+    },
+  };
+  ```
+
+  Note: `checkField()` does not handle `'boolean'` type today — add boolean support to `checkField()`. The existing function body:
+  ```js
+  function checkField(obj, field, expectedType, errors) {
+    if (!(field in obj)) {
+      errors.push(`missing required field: ${field}`);
+      return;
+    }
+    if (expectedType === 'array') {
+      if (!Array.isArray(obj[field])) errors.push(`${field}: expected array, got ${typeof obj[field]}`);
+    } else if (typeof obj[field] !== expectedType) {
+      errors.push(`${field}: expected ${expectedType}, got ${typeof obj[field]}`);
+    }
+  }
+  ```
+  `'boolean'` falls through to the `typeof` branch which already handles it correctly (`typeof true === 'boolean'`). No change needed — verify this manually before Step 2.
+
+- [ ] **Step 2: Verify boolean type check works without code change**
+
+  Run:
+  ```bash
+  node -e "
+  const obj = { f: true };
+  const errors = [];
+  function checkField(o, field, expectedType, errs) {
+    if (!(field in o)) { errs.push('missing required field: ' + field); return; }
+    if (expectedType === 'array') {
+      if (!Array.isArray(o[field])) errs.push(field + ': expected array, got ' + typeof o[field]);
+    } else if (typeof o[field] !== expectedType) {
+      errs.push(field + ': expected ' + expectedType + ', got ' + typeof o[field]);
+    }
+  }
+  checkField(obj, 'f', 'boolean', errors);
+  console.log(errors.length === 0 ? 'PASS: boolean handled correctly' : 'FAIL: ' + errors);
+  "
+  ```
+  Expected: `PASS: boolean handled correctly`
+
+- [ ] **Step 3: Create the valid fixture**
+
+  Create `hooks/scripts/fixtures/valid-design-document.json`:
+  ```json
+  {
+    "schema_version": 1,
+    "phase": "design-document",
+    "status": "success",
+    "design_issue_url": "https://github.com/uta2000/feature-flow/issues/251",
+    "issue_number": 251,
+    "design_section_present": true,
+    "key_decisions": ["Pattern B for fanout phases", "schema_version: 1 for contracts"],
+    "open_questions": [],
+    "tbd_count": 0
+  }
+  ```
+
+- [ ] **Step 4: Run validator against fixture — verify exit 0**
+
+  Run:
+  ```bash
+  node hooks/scripts/validate-return-contract.js hooks/scripts/fixtures/valid-design-document.json
+  ```
+  Expected output: `[validate-return-contract] OK`
+  Expected exit code: 0
+
+- [ ] **Step 5: Add design-document test cases to validate-return-contract.test.js**
+
+  Read `hooks/scripts/validate-return-contract.test.js` lines 33-103 first. Then add after the last `test(...)` call and before `console.log(...)`:
+
+  ```js
+  // --- design-document contract tests ---
+
+  const VALID_DD = {
+    schema_version: 1,
+    phase: 'design-document',
+    status: 'success',
+    design_issue_url: 'https://github.com/uta2000/feature-flow/issues/251',
+    issue_number: 251,
+    design_section_present: true,
+    key_decisions: ['Pattern B', 'schema_version 1'],
+    open_questions: [],
+    tbd_count: 0,
+  };
+
+  test('design-document: valid contract exits 0', () => {
+    const p = writeFixture(VALID_DD);
+    const r = run(p);
+    if (r.code !== 0) throw new Error(`expected exit 0, got ${r.code}\n${r.stderr}`);
+  });
+
+  test('design-document: missing design_issue_url exits 1', () => {
+    const bad = { ...VALID_DD }; delete bad.design_issue_url;
+    const p = writeFixture(bad);
+    const r = run(p);
+    if (r.code === 0) throw new Error('expected non-zero exit for missing design_issue_url');
+    if (!r.stdout.includes('missing required field')) throw new Error(`expected "missing required field" in output; got: ${r.stdout}`);
+  });
+
+  test('design-document: missing issue_number exits 1', () => {
+    const bad = { ...VALID_DD }; delete bad.issue_number;
+    const p = writeFixture(bad);
+    const r = run(p);
+    if (r.code === 0) throw new Error('expected non-zero exit for missing issue_number');
+  });
+
+  test('design-document: design_section_present as string exits 1', () => {
+    const bad = { ...VALID_DD, design_section_present: 'true' };
+    const p = writeFixture(bad);
+    const r = run(p);
+    if (r.code === 0) throw new Error('expected non-zero exit for string design_section_present');
+  });
+
+  test('design-document: invalid status exits 1', () => {
+    const bad = { ...VALID_DD, status: 'unknown' };
+    const p = writeFixture(bad);
+    const r = run(p);
+    if (r.code === 0) throw new Error('expected non-zero exit for invalid status');
+  });
+
+  test('design-document: partial status is valid', () => {
+    const partial = { ...VALID_DD, status: 'partial', open_questions: ['What about X?'] };
+    const p = writeFixture(partial);
+    const r = run(p);
+    if (r.code !== 0) throw new Error(`expected exit 0 for partial status; got ${r.code}\n${r.stderr}`);
+  });
+
+  test('design-document: failed status is valid', () => {
+    const failed_status = { ...VALID_DD, status: 'failed', design_section_present: false };
+    const p = writeFixture(failed_status);
+    const r = run(p);
+    if (r.code !== 0) throw new Error(`expected exit 0 for failed status; got ${r.code}\n${r.stderr}`);
+  });
+
+  test('design-document: tbd_count as string exits 1', () => {
+    const bad = { ...VALID_DD, tbd_count: 'zero' };
+    const p = writeFixture(bad);
+    const r = run(p);
+    if (r.code === 0) throw new Error('expected non-zero exit for string tbd_count');
+  });
+  ```
+
+- [ ] **Step 6: Run all tests — verify 0 failures**
+
+  Run:
+  ```bash
+  node hooks/scripts/validate-return-contract.test.js
+  ```
+  Expected: all tests PASS, `Results: N passed, 0 failed` (N >= 16)
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  cd /Users/weee/Dev/feature-flow/.worktrees/design-document-pattern-b-e886
+  git add hooks/scripts/validate-return-contract.js hooks/scripts/validate-return-contract.test.js hooks/scripts/fixtures/valid-design-document.json
+  git commit -m "feat(validator): add design-document schema entry + fixtures + unit tests (#251)"
+  ```
+</task>
+
+<task id="3" status="pending">
+### Task 3: Modify skills/design-document/SKILL.md — findings_path + write_contract_to + Step 5
+
+**Files:**
+- Modify: `skills/design-document/SKILL.md` (add `findings_path` arg branch at top of Step 1; add `write_contract_to`, `phase_id` optional args; add Step 5 Write Return Contract)
+
+**Step numbering note:** The existing SKILL.md has Steps 1–4 then `### Step: Optional codex review` (unnumbered). Adding a numbered "Step 5: Write Return Contract" inserts before the codex-review section. The codex review step remains unnumbered to avoid renumbering it. The `grep -c "Step 5"` acceptance criterion below verifies exactly one match.
+
+
+**Quality Constraints:**
+- Error handling: Step 5 python3 helper must use the `[ -f "$F" ]` guard (matching `skills/verify-plan-criteria/SKILL.md:326` pattern). Absence of state file is a warning, not a fatal error.
+- Function length: Python3 helpers are inline `-c` one-liners — no extraction needed. Bash variable blocks must not exceed 20 lines.
+- Pattern reference: Step 7 helper in `skills/verify-plan-criteria/SKILL.md:270-330` is the exact template for Step 5 (verify-plan-criteria has it as Step 7; design-document has it as Step 5 because the file has fewer steps).
+
+**CRITICAL — phase/bucket confusion:**
+- Step 5 helper sets `phase_id` default to `design` (the bucket key — one of `{brainstorm, design, plan, implementation}`).
+- The contract's `"phase"` field is hardcoded to `"design-document"` (the lifecycle step name) — NOT the bucket key.
+- Add explicit comment in the python3 helper: `# bucket key in phase_summaries (e.g. "design") — NOT the step name ("design-document")`
+- Quality Constraint on this task: "Pass `phase_id: design` (bucket key) NOT `design-document` (step name). Contract field stays `phase: design-document`. Verify in self-review."
+
+**Acceptance criteria:**
+- [ ] `grep -n "findings_path" skills/design-document/SKILL.md | head -5` outputs at least 2 lines (arg declaration + branch in Step 1) — measured by: `grep -c "findings_path" skills/design-document/SKILL.md` outputs `>= 2`
+- [ ] `grep -n "write_contract_to" skills/design-document/SKILL.md | head -5` outputs at least 2 lines (arg declaration + Step 5 reference) — measured by: `grep -c "write_contract_to" skills/design-document/SKILL.md` outputs `>= 2`
+- [ ] `grep -n "Step 5" skills/design-document/SKILL.md` outputs exactly 1 line — measured by: `grep -c "Step 5" skills/design-document/SKILL.md` outputs `1`
+- [ ] `grep "phase.*design-document" skills/design-document/SKILL.md` matches the hardcoded contract phase string — measured by: `grep -c '"design-document"' skills/design-document/SKILL.md` outputs `>= 1`
+- [ ] `grep '"design"' skills/design-document/SKILL.md | grep "bucket"` returns the comment confirming bucket key — measured by: `grep -c "bucket" skills/design-document/SKILL.md` outputs `>= 1`
+
+**Steps:**
+
+- [ ] **Step 1: Read the full SKILL.md before editing**
+
+  Run:
+  ```bash
+  wc -l skills/design-document/SKILL.md
+  ```
+  Then read `skills/design-document/SKILL.md` fully (the file is ~260 lines — read it all).
+
+- [ ] **Step 2: Add Optional Args section after the frontmatter block**
+
+  After line 5 (`tools: Read, Glob, Grep, Write, Edit, AskUserQuestion, Task`) and before the `# Design Document` heading, insert:
+
+  ```markdown
+  ## Optional Args (used when invoked from orchestrator Pattern B dispatch)
+
+  When invoked as a Pattern B consolidator subagent (per #251), the orchestrator passes these additional arguments:
+
+  - `findings_path: <absolute-path-to-json>` — when set, read pre-gathered Explore agent findings from this JSON file and **skip Step 1's agent dispatch entirely**. Jump directly to the consolidation block in Step 1.
+  - `write_contract_to: <absolute-path-to-in-progress-yml>` — when set, write the return contract to `phase_summaries.<phase_id>.return_contract` in the YAML state file after Step 4 completes (see Step 5 below).
+  - `phase_id: <bucket-name>` — identifies which `phase_summaries` bucket to write into. Must be one of `{brainstorm, design, plan, implementation}`. If absent when `write_contract_to` is set, defaults to `design`. **Do not confuse `phase_id` with the contract's own `phase` field** — `phase_id` is the bucket key (`design`), the contract's `phase` field is the lifecycle step name (`design-document`) per #251's locked spec.
+
+  All three args are optional. If `findings_path` is absent, Step 1 runs normally (agent dispatch). If `write_contract_to` is absent, Step 5 is skipped — the skill behaves identically to its inline-invocation form.
+  ```
+
+- [ ] **Step 3: Add findings_path branch at top of Step 1**
+
+  In the `### Step 1: Gather Context` section, after the opening paragraph ("Collect the inputs needed to write the document:") and before the `1. **From the conversation:**` list, insert:
+
+  ```markdown
+  **`findings_path` short-circuit (Pattern B only):** If `findings_path` is present in ARGUMENTS, the orchestrator has already dispatched the parallel Explore agents and written their results to a JSON file at that path. In this case:
+  1. Read the JSON file at `findings_path`. It contains an array of `{area: string, findings: string[]}` objects.
+  2. Use these as the agent findings for the Consolidation block below — skip the agent dispatch entirely.
+  3. Jump directly to **Consolidation** (do not dispatch Task agents, do not announce parallel dispatch).
+
+  If `findings_path` is absent, continue with the standard agent dispatch below.
+  ```
+
+- [ ] **Step 4: Add Step 5 Write Return Contract section**
+
+  Insert before `### Step: Optional codex review` (the unnumbered last section). The section is inserted between Step 4 (Merge design into GitHub issue body) and the codex review step, keeping codex review as the trailing unnumbered section.
+
+  Insert:
+
+  ```markdown
+  ### Step 5: Write Return Contract (conditional)
+
+  **Only executes if `write_contract_to` is set in the skill's ARGUMENTS.** If the arg is absent, skip this step entirely.
+
+  Construct the return contract object per the locked spec from #251:
+
+  - `schema_version`: `1` (integer — contract schema version, NOT the in-progress state-file schema_version)
+  - `phase`: hardcoded to `"design-document"` per #251's locked contract spec — this is the lifecycle step name the validator uses to look up the schema. **Not** the `phase_id` arg value. (`phase_id` names the state-file bucket, e.g. `"design"`.)
+  - `status`: one of:
+    - `"success"` — design section written to issue body, markers present and confirmed
+    - `"partial"` — design written but some fields could not be determined (e.g., `open_questions` uncertain)
+    - `"failed"` — skill could not write design to issue (e.g., `gh` command failed)
+  - `design_issue_url`: URL of the GitHub issue containing the design (from `gh issue view <issue_number> --json url --jq '.url'`)
+  - `issue_number`: integer issue number from lifecycle context
+  - `design_section_present`: `true` if `<!-- feature-flow:design:start -->` and `<!-- feature-flow:design:end -->` markers are present in the issue body after Step 4 completes; `false` otherwise
+  - `key_decisions`: array of up to 5 key decision strings extracted from the design doc (scope choices, approach choices, rejected alternatives) — empty array if none
+  - `open_questions`: array of unresolved question strings (`[TBD]` items) found in the design — empty array if none
+  - `tbd_count`: integer count of `[TBD]` markers in the design body (0 if none)
+
+  Write the contract to the state file using this helper (env-var passing pattern — apostrophe-safe):
+
+  ```bash
+  F="<write_contract_to value>"
+  PHASE_ID="<phase_id value, default: design>"  # bucket key in phase_summaries (e.g. "design") — NOT the step name ("design-document")
+  STATUS="<success|partial|failed>"
+  ISSUE_URL="<design_issue_url>"
+  ISSUE_NUM=<issue_number>
+  SECTION_PRESENT=<true|false>
+  KEY_DECISIONS='<json-array-string, e.g. ["Decision A","Decision B"] or []>'
+  OPEN_QUESTIONS='<json-array-string, e.g. ["Question X"] or []>'
+  TBD_COUNT=<integer>
+
+  [ -f "$F" ] && F="$F" PHASE_ID="$PHASE_ID" STATUS="$STATUS" ISSUE_URL="$ISSUE_URL" ISSUE_NUM="$ISSUE_NUM" SECTION_PRESENT="$SECTION_PRESENT" KEY_DECISIONS="$KEY_DECISIONS" OPEN_QUESTIONS="$OPEN_QUESTIONS" TBD_COUNT="$TBD_COUNT" python3 -c '
+  import os, json, yaml
+  f = os.environ["F"]
+  d = yaml.safe_load(open(f)) or {}
+  bucket = os.environ["PHASE_ID"]  # bucket key in phase_summaries (e.g. "design") — NOT the step name ("design-document")
+  if "phase_summaries" not in d or bucket not in d["phase_summaries"]:
+      print(f"[design-document] WARNING: phase_summaries.{bucket} not found in {f}; skipping contract write")
+  else:
+      d["phase_summaries"][bucket]["return_contract"] = {
+          "schema_version": 1,
+          # The contract phase field is the lifecycle STEP NAME per #251 spec
+          # ("design-document"), NOT the bucket key (which would be "design").
+          # The validator uses this to look up the schema in its registry.
+          "phase": "design-document",
+          "status": os.environ["STATUS"],
+          "design_issue_url": os.environ["ISSUE_URL"],
+          "issue_number": int(os.environ["ISSUE_NUM"]),
+          "design_section_present": os.environ["SECTION_PRESENT"].lower() == "true",
+          "key_decisions": json.loads(os.environ["KEY_DECISIONS"]),
+          "open_questions": json.loads(os.environ["OPEN_QUESTIONS"]),
+          "tbd_count": int(os.environ["TBD_COUNT"]),
+      }
+      yaml.dump(d, open(f, "w"), default_flow_style=False, allow_unicode=True)
+      print(f"[design-document] return_contract written to {f}")
+  '
+  ```
+
+  The `[ -f "$F" ]` guard is intentional — when invoked outside a lifecycle context, `write_contract_to` may point to a file that does not exist. Log warning and return normally.
+
+  After writing, return the state-file path and a one-line summary as the skill's result text:
+
+  `"Return contract written to <write_contract_to>. Design issue: #<issue_number>. Design section present: <true|false>. Status: <status>."`
+
+  **CRITICAL self-review check:** Verify `PHASE_ID` default is `design` (bucket key) — NOT `design-document` (step name). The contract's `"phase"` field is `"design-document"`. These are two distinct values.
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  cd /Users/weee/Dev/feature-flow/.worktrees/design-document-pattern-b-e886
+  git add skills/design-document/SKILL.md
+  git commit -m "feat(design-document): add findings_path arg + write_contract_to Step 5 (Write Return Contract) for Pattern B (#251)"
+  ```
+</task>
+
+<task id="4" status="pending">
+### Task 4: Add Pattern B wrapper subsection to skills/start/SKILL.md + update behavioral call sites
+
+**Files:**
+- Modify: `skills/start/SKILL.md` at lines 689-690 (replace YOLO Task() dispatch), lines 752-756 and 763 (replace Interactive/Express Skill() calls), and insert new subsection at ~line 752 (after existing Pattern A wrapper)
+
+**Quality Constraints:**
+- Error handling: Inline-fallback table must cover exactly 3 cases (dispatch fails, subagent completes but contract absent, validator fails) — same as Pattern A wrapper at lines 737-744.
+- Function length: No function to extract — this is a Markdown skill file. Wrapper subsection must be self-contained (all dispatch params, post-dispatch sequence, fallback table, sunset comment).
+- Pattern reference: Mirror Pattern A wrapper block at `skills/start/SKILL.md:697-751` structurally. Match: header note, all-modes dispatch code block, post-dispatch sequence, fallback table, sunset comment.
+
+**CRITICAL — phase/bucket confusion:**
+- The wrapper prompt MUST pass `phase_id: design` (bucket key) to the consolidator.
+- The validator MUST look up the contract by `obj.phase` which will be `"design-document"` (step name) — do NOT pass `phase_id: design-document` in the dispatch args.
+- Add explicit comment in the wrapper subsection (mirroring the "Why `phase_id: plan` (not `verify-plan-criteria`)" note at line 719): "**Why `phase_id: design` (not `design-document`):** `phase_id` names the **state-file bucket** in `phase_summaries` — one of the four fixed keys (`brainstorm`, `design`, `plan`, `implementation`). The `design-document` lifecycle step lives in the `design` bucket. The contract's own `phase` field stays `"design-document"` per #251's locked spec."
+- Quality Constraint: "Pass `phase_id: design` (bucket key) NOT `design-document` (step name). Contract field stays `phase: design-document`. Verify in self-review."
+
+**Inline-fallback target:**
+- The fallback for Interactive/Express/YOLO cases is `Skill(skill: "feature-flow:design-document", args: "yolo: true. scope: [scope]. [original args]")` — the pre-#251 inline form.
+- The existing YOLO Task() at L689-690 is **NOT** a valid fallback — it is latently broken (subagent tries to dispatch inner Explore agents which is blocked by Q1's recursive dispatch constraint). The inline Skill() is the only safe fallback.
+
+**Acceptance criteria:**
+- [ ] `grep -n "Design Document.*Pattern B" skills/start/SKILL.md` outputs 1 line — measured by: `grep -c "Pattern B" skills/start/SKILL.md` outputs `>= 2` (Pattern A at line 678 + new Pattern B subsection heading)
+- [ ] `grep -n "phase_id: design" skills/start/SKILL.md` outputs at least 1 line in the new wrapper — measured by: `grep -c "phase_id: design" skills/start/SKILL.md` outputs `>= 1`
+- [ ] Lines 689-690 no longer contain the old YOLO Task() dispatch for design-document — measured by: `sed -n '686,694p' skills/start/SKILL.md | grep -c "YOLO design document"` outputs `0`
+- [ ] Lines 752-756 no longer contain the old Interactive/Express inline Skill() for design-document — measured by: `grep -n 'Skill.*feature-flow:design-document.*yolo: true' skills/start/SKILL.md | grep -v "fallback"` outputs 0 lines (all remaining references are inside fallback tables or sunset comments)
+- [ ] `grep -n "sunset" skills/start/SKILL.md | grep -i "design"` outputs at least 1 match — measured by: `grep -c "SUNSET NOTE.*design\|design.*sunset" skills/start/SKILL.md` outputs `>= 1` (case-insensitive)
+
+**Steps:**
+
+- [ ] **Step 1: Read lines 670-770 of start/SKILL.md before editing**
+
+  Run:
+  ```bash
+  sed -n '670,770p' skills/start/SKILL.md | cat -n
+  ```
+  Verify the exact content at L689-690 (YOLO Task), L752-756 (Interactive/Express block), L763 (Express Skill call).
+
+- [ ] **Step 2: Replace L689-690 YOLO Task() with reference to new wrapper**
+
+  Find and replace the YOLO design-document Task block. Current text at L688-691:
+  ```
+  # Design document — Opus for architectural decisions
+  Task(subagent_type: "general-purpose", model: "opus", description: "YOLO design document",
+       prompt: "Invoke Skill(skill: 'feature-flow:design-document', args: 'yolo: true. scope: [scope]. [context args]'). Return the design document path and key decisions.")
+  ```
+
+  Replace with:
+  ```
+  # Design document — Pattern B (see "Design Document — Pattern B Dispatch" subsection below)
+  # In YOLO mode the orchestrator dispatches Explore fanout + consolidator Task() directly.
+  # See "Design Document — Pattern B Dispatch" for the full dispatch sequence.
+  ```
+
+- [ ] **Step 3: Insert new Pattern B wrapper subsection at ~line 752 (after existing Pattern A wrapper)**
+
+  After the `<!-- SUNSET NOTE ... -->` comment block that closes the Pattern A wrapper (at ~line 750), insert the new subsection. The insertion point is just before the current L752 `**Interactive/Express mode**` paragraph.
+
+  Insert this full block:
+
+  ````markdown
+  ### Design Document — Pattern B Dispatch
+
+  **Note:** INLINE-FALLBACK IS A ROLLOUT-ONLY FEATURE.
+  <!-- feature-flow vNEXT removes inline-fallback once two consecutive successful real-session uses are observed. -->
+
+  **Applies in ALL modes** (YOLO, Express, Interactive). `design-document` is the first Pattern B conversion (per issue #251). The orchestrator dispatches parallel Explore agents (hoisted from `skills/design-document/SKILL.md` Step 1), writes findings to a temp JSON file, then dispatches a consolidator `Task()` subagent that invokes the skill with `findings_path` pointing to that file (skipping inner agent dispatch). The consolidator writes a structured return contract to the in-progress state file; the orchestrator validates before proceeding.
+
+  ```
+  # Step: Design document (Pattern B)
+  BASE_REPO=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+  SLUG=<slug-from-session-context>
+  STATE_FILE="${BASE_REPO}/.feature-flow/handoffs/in-progress-${SLUG}.yml"
+  FINDINGS_FILE="/tmp/ff-design-findings-${SLUG}.json"
+
+  # Phase 1: Orchestrator-side Explore fanout (3-4 agents in parallel, single message)
+  # Returns: [{area: string, findings: string[]}, ...]
+  Task(subagent_type: "Explore", model: "haiku", description: "design-document context: format patterns",
+       prompt: "Read existing design docs in docs/plans/ and extract document structure, section patterns, and conventions. Return JSON: {area: 'format-patterns', findings: [<string>, ...]}")
+  Task(subagent_type: "Explore", model: "haiku", description: "design-document context: stack & dependencies",
+       prompt: "Examine dependency files (package.json, config files), project structure, and tech stack conventions. Return JSON: {area: 'stack-dependencies', findings: [<string>, ...]}")
+  Task(subagent_type: "Explore", model: "haiku", description: "design-document context: relevant code",
+       prompt: "Search for and read source files related to <feature description>. Return JSON: {area: 'relevant-code', findings: [<string>, ...]}")
+  # Optional 4th agent: Context7 docs — only if .feature-flow.yml has context7 field AND no doc lookup ran in start
+  # Task(subagent_type: "Explore", model: "haiku", description: "design-document context: documentation", ...)
+
+  # Write findings to temp JSON file
+  python3 -c "
+  import json, sys
+  findings = [<agent1_result>, <agent2_result>, <agent3_result>]  # collect from Task returns
+  json.dump(findings, open('${FINDINGS_FILE}', 'w'))
+  print('[design-document] findings written to ${FINDINGS_FILE}')
+  "
+
+  # Phase 2: Consolidator dispatch
+  Task(
+    subagent_type: "general-purpose",
+    model: "sonnet",
+    description: "design-document Pattern B consolidator",
+    prompt: "Invoke Skill(skill: 'feature-flow:design-document', args: 'yolo: true. scope: [scope]. issue: [issue_number]. design_issue: [design_issue]. findings_path: ${FINDINGS_FILE}. write_contract_to: ${STATE_FILE}. phase_id: design'). Return the state-file path and a one-line summary."
+  )
+  ```
+
+  **Why `phase_id: design` (not `design-document`):** `phase_id` names the **state-file bucket** in `phase_summaries` — one of the four fixed keys (`brainstorm`, `design`, `plan`, `implementation`). The `design-document` lifecycle step lives in the `design` bucket. The contract's own `phase` field stays `"design-document"` per #251's locked spec. Two distinct concepts, same word "phase" — don't confuse them.
+
+  **Why `model: "sonnet"` for consolidator (settled — not an open question):** The removed YOLO Task() at L689-690 used `model: "opus"`. That wrapper was for original architectural reasoning ("Opus for creative decisions"). The Pattern B consolidator does synthesis — it ingests pre-gathered findings and writes structured sections from them. That is the same work shape as `verify-plan-criteria` (read + synthesize + output structured result), which correctly uses Sonnet. Opus is over-spec for synthesis; Sonnet matches the work. Decision is locked.
+
+  **Post-dispatch sequence (orchestrator-side):**
+
+  1. **Read state file** and extract `phase_summaries.design.return_contract`:
+     ```bash
+     python3 -c "import json, yaml; d = yaml.safe_load(open('${STATE_FILE}')); rc = (d.get('phase_summaries', {}).get('design') or {}).get('return_contract'); json.dump(rc, open('/tmp/ff-return-contract-${SLUG}.json','w')) if rc else None; print('missing' if not rc else 'ok')"
+     ```
+     If output is `missing` → trigger **inline-fallback** (case 2 below).
+  2. **Validate the contract:**
+     ```bash
+     node hooks/scripts/validate-return-contract.js /tmp/ff-return-contract-${SLUG}.json
+     ```
+     Exit 0 → proceed. Non-zero → trigger **inline-fallback** (case 3 below).
+  3. **Proceed to next lifecycle step** (Design verification / Create issue / Implementation plan).
+
+  **Inline-fallback path** (rollout-only — three failure cases):
+
+  | Case | Trigger | Announce | Next |
+  |------|---------|----------|------|
+  | 1 | Explore fanout dispatch fails (timeout, tool error, refusal) or consolidator `Task()` dispatch fails | `design-document Pattern B: dispatch failed (<reason>). Falling back to inline Skill().` | Run inline `Skill(skill: "feature-flow:design-document", args: "yolo: true. scope: [scope]. [original args]")` |
+  | 2 | Consolidator completes but `return_contract` field is null/absent in state file | `design-document Pattern B: subagent did not write return_contract. Falling back to inline Skill().` | Same inline invocation |
+  | 3 | `validate-return-contract.js` exits non-zero | `design-document Pattern B: contract validation failed (<error from validator>). Falling back to inline Skill().` | Same inline invocation |
+
+  The inline fallback is `Skill(skill: "feature-flow:design-document", args: "yolo: true. scope: [scope]. [original args]")` — the pre-#251 inline form. **Do NOT fall back to the old YOLO Task() at L689-690 (removed) — that dispatch is latently broken because the subagent cannot recursively dispatch Explore agents (Q1 spike result).**
+
+  <!-- SUNSET NOTE: feature-flow vNEXT removes this inline-fallback table and the three failure-case
+       handlers once two consecutive successful real-session uses of Pattern B are observed and the
+       measurement (per #253) confirms ≥5% orchestrator context reduction. The wrapper itself stays;
+       only the fallback safety net is sunset. -->
+  ````
+
+- [ ] **Step 4: Update the Interactive/Express mode paragraph and code blocks at ~L752-764**
+
+  The current paragraph starts with `**Interactive/Express mode** continues to use inline Skill calls for **brainstorming and design-document**...`. Update it to remove `design-document` from the inline-call description:
+
+  Replace the current paragraph + code blocks at ~L752-764 with:
+
+  ```markdown
+  **Interactive/Express mode** for **brainstorming** continues to use inline `Skill` calls (unchanged — brainstorming inherits the parent model and requires user interaction in Interactive mode). **design-document** now uses Pattern B dispatch in all modes (see "Design Document — Pattern B Dispatch" subsection above). Pattern A subagent dispatches (e.g. `verify-plan-criteria`) still use `Task()` in Interactive/Express modes for context isolation, not model routing.
+
+  ```
+  Skill(skill: "superpowers:brainstorming", args: "yolo: true. scope: [scope]. [original args]")
+  ```
+
+  **Express Propagation:** When Express mode is active, prepend `express: true. scope: [scope].` to the `args` parameter of every `Skill` invocation. Express inherits all YOLO auto-selection overrides — skills that check for `yolo: true` should also check for `express: true` and behave the same way (auto-select decisions). The only difference is at the orchestrator level where checkpoints are shown instead of suppressed.
+
+  ```
+  Skill(skill: "superpowers:brainstorming", args: "express: true. scope: [scope]. [original args]")
+  ```
+  ```
+
+- [ ] **Step 5: Verify line references after edit**
+
+  Run:
+  ```bash
+  grep -n "Pattern B Dispatch\|phase_id: design\|YOLO design document\|Skill.*feature-flow:design-document" skills/start/SKILL.md | head -20
+  ```
+  Confirm:
+  - `Pattern B Dispatch` appears in the new subsection heading
+  - `phase_id: design` appears in the dispatch prompt
+  - `YOLO design document` does NOT appear (old Task removed)
+  - `Skill.*feature-flow:design-document` only appears in fallback table and inline-fallback instructions (not as a primary call site)
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  cd /Users/weee/Dev/feature-flow/.worktrees/design-document-pattern-b-e886
+  git add skills/start/SKILL.md
+  git commit -m "feat(start): Pattern B wrapper for design-document phase; replace L689-690 YOLO Task + L752/763 Skill() (#251)"
+  ```
+</task>
+
+<task id="5" status="pending">
+### Task 5: Update doc-only lines in skills/start/SKILL.md
+
+**Files:**
+- Modify: `skills/start/SKILL.md` at L678 (Pattern A/B CRITICAL block), L844 (Skill Mapping table), L951 (YOLO stop_after phase mapping table)
+
+**Quality Constraints:**
+- These are documentation-only edits. No logic changes. Verify with `git diff --stat` that only `skills/start/SKILL.md` is modified.
+- Pattern reference: match the `verify-plan-criteria` row format in the Skill Mapping table at line 849.
+
+**Acceptance criteria:**
+- [ ] `grep -n "Future conversions.*design-document" skills/start/SKILL.md` outputs 0 lines — measured by: `grep -c "Future conversions.*design-document" skills/start/SKILL.md` outputs `0`
+- [ ] L678 "Currently converted" list includes design-document — measured by: `grep -c "Currently converted.*design-document" skills/start/SKILL.md` outputs `>= 1`
+- [ ] `grep -n "Design document.*Pattern B\|Pattern B.*design-document" skills/start/SKILL.md | head -5` outputs at least 1 match in the Skill Mapping row — measured by: `sed -n '840,850p' skills/start/SKILL.md | grep -c "Pattern B"` outputs `>= 1`
+
+**Steps:**
+
+- [ ] **Step 1: Read lines 675-682 and 840-855 and 948-958 before editing**
+
+  Run:
+  ```bash
+  sed -n '675,682p' skills/start/SKILL.md
+  sed -n '840,855p' skills/start/SKILL.md
+  sed -n '948,958p' skills/start/SKILL.md
+  ```
+
+- [ ] **Step 2: Update L678 Pattern A/B CRITICAL block — move design-document to "Currently converted"**
+
+  In the `**Pattern A subagent dispatch (CRITICAL...)**` paragraph at L678, find the sentence:
+  ```
+  Currently converted: `verify-plan-criteria` (see "Verify Plan Criteria — Pattern A Dispatch" subsection below). Future conversions: `merge-prs`, `design-document`, `verify-acceptance-criteria`, `code-review`, `implementation` per #251's conversion order.
+  ```
+
+  Replace with:
+  ```
+  Currently converted: `verify-plan-criteria` (Pattern A — see "Verify Plan Criteria — Pattern A Dispatch" subsection below), `design-document` (Pattern B — see "Design Document — Pattern B Dispatch" subsection below). Future conversions: `merge-prs`, `verify-acceptance-criteria`, `code-review`, `implementation` per #251's conversion order.
+  ```
+
+- [ ] **Step 3: Update Skill Mapping table row for Design document**
+
+  In the Skill Mapping table, find the row:
+  ```
+  | Design document | `feature-flow:design-document` | GitHub issue body (between `<!-- feature-flow:design:start -->` markers) **Context capture:** After the design document is written to the issue body, write key scope decisions, approach choices, and rejected alternatives to `.feature-flow/design/design-decisions.md` (append to the existing template — do not overwrite). |
+  ```
+
+  Replace the `Expected Output` column content with:
+  ```
+  GitHub issue body (between `<!-- feature-flow:design:start -->` markers); structured return contract at `phase_summaries.design.return_contract` validated via `hooks/scripts/validate-return-contract.js` (Pattern B dispatch — see "Design Document — Pattern B Dispatch" section). **Context capture:** After the design document is written to the issue body, write key scope decisions, approach choices, and rejected alternatives to `.feature-flow/design/design-decisions.md` (append to the existing template — do not overwrite).
+  ```
+
+- [ ] **Step 4: Update YOLO stop_after phase mapping table row for design**
+
+  In the `stop_after` phase mapping table, find the row:
+  ```
+  | `design` | Design document | After `feature-flow:design-document` returns |
+  ```
+
+  Update the `Fires after/before` column to:
+  ```
+  After `feature-flow:design-document` Pattern B consolidator returns (after contract written to state file)
+  ```
+
+- [ ] **Step 5: Verify no regressions in the doc lines**
+
+  Run:
+  ```bash
+  grep -n "design-document\|Pattern B" skills/start/SKILL.md | head -30
+  ```
+  Confirm: L678 updated, Skill Mapping row updated, stop_after table updated, no stale references to old inline call pattern.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  cd /Users/weee/Dev/feature-flow/.worktrees/design-document-pattern-b-e886
+  git add skills/start/SKILL.md
+  git commit -m "docs(start): move design-document to currently converted; update skill mapping + stop_after table (#251)"
+  ```
+</task>
+
+<task id="6" status="pending">
+### Task 6: Extend e2e test for design-document contract round-trip
+
+**Files:**
+- Modify: `hooks/scripts/validate-return-contract.e2e.sh` (add a second round-trip test covering the `design-document` bucket/step-name distinction)
+
+**Quality Constraints:**
+- Error handling: Use `set -euo pipefail`. All temp files must be cleaned up via `trap cleanup EXIT`.
+- Function length: the new e2e block must be self-contained — no new bash functions. Follow the inline env-var passing pattern at e2e.sh:54-78 exactly.
+- Pattern reference: `hooks/scripts/validate-return-contract.e2e.sh` (existing `verify-plan-criteria` round-trip at lines 28-93) is the exact template.
+
+**CRITICAL — phase/bucket confusion test:**
+- The e2e test must explicitly verify that bucket key `design` and contract `phase` field `design-document` are distinct by:
+  1. Writing the return contract to `phase_summaries.design.return_contract` (bucket = `design`)
+  2. Reading it back via `phase_summaries.design.return_contract`
+  3. Validating that `obj.phase === "design-document"` (step name) passes the validator
+
+**Acceptance criteria:**
+- [ ] `bash hooks/scripts/validate-return-contract.e2e.sh` exits 0 — measured by: `echo $?` outputs `0`
+- [ ] `bash hooks/scripts/validate-return-contract.e2e.sh` outputs exactly 2 `e2e PASS` lines (one for verify-plan-criteria, one for design-document) — measured by: `bash hooks/scripts/validate-return-contract.e2e.sh | grep -c "e2e PASS"` outputs `2`
+
+**Steps:**
+
+- [ ] **Step 1: Read the full existing e2e.sh before editing**
+
+  Run: `wc -l hooks/scripts/validate-return-contract.e2e.sh` then read it fully.
+
+- [ ] **Step 2: Add design-document round-trip test block**
+
+  At the end of `hooks/scripts/validate-return-contract.e2e.sh` (after line 93 `echo "  e2e PASS: ..."`), append:
+
+  ```bash
+  # ============================================================
+  # design-document contract round-trip (Pattern B, bucket: design)
+  # Verifies that bucket key 'design' and contract phase 'design-document' are distinct.
+  # ============================================================
+
+  SLUG_DD="e2e-dd-$(date +%s)-$$"
+  STATE_FILE_DD="/tmp/in-progress-${SLUG_DD}.yml"
+  CONTRACT_JSON_DD="/tmp/ff-return-contract-${SLUG_DD}.json"
+
+  cleanup_dd() { rm -f "$STATE_FILE_DD" "$CONTRACT_JSON_DD"; }
+  trap cleanup_dd EXIT
+
+  # Step 1: fake state file with 4-bucket schema.
+  SLUG_DD="$SLUG_DD" STATE_FILE_DD="$STATE_FILE_DD" python3 -c '
+  import os, yaml
+  data = {
+      "schema_version": 2,
+      "slug": os.environ["SLUG_DD"],
+      "issue_number": 251,
+      "worktree_path": "/tmp",
+      "branch": "test",
+      "base_branch": "main",
+      "scope": "feature",
+      "current_step": "design-document",
+      "last_completed_step": "brainstorm",
+      "created_at": "2026-05-02T00:00:00Z",
+      "updated_at": "2026-05-02T00:00:00Z",
+      "phase_summaries": {
+          "brainstorm":     {"completed": True,  "key_decisions": [],                     "return_contract": None},
+          "design":         {"completed": False, "issue_url": None, "key_decisions": [],  "return_contract": None},
+          "plan":           {"completed": False, "plan_path": None, "open_questions": [], "return_contract": None},
+          "implementation": {"completed": False, "tasks_done": 0, "tasks_total": 0, "blockers": [], "return_contract": None},
+      },
+      "feature_flow_version": "1.37.0",
+  }
+  yaml.dump(data, open(os.environ["STATE_FILE_DD"], "w"), default_flow_style=False, allow_unicode=True)
+  '
+
+  # Step 2: skill Step 5 helper — subagent writes its return contract to the 'design' BUCKET.
+  # NOTE: phase_summaries bucket = 'design'; contract phase field = 'design-document'
+  F="$STATE_FILE_DD" PHASE_ID="design" STATUS="success" \
+  ISSUE_URL="https://github.com/uta2000/feature-flow/issues/251" \
+  ISSUE_NUM="251" SECTION_PRESENT="true" \
+  KEY_DECISIONS='["Pattern B for fanout phases"]' \
+  OPEN_QUESTIONS='[]' TBD_COUNT="0" python3 -c '
+  import os, json, yaml
+  f = os.environ["F"]
+  d = yaml.safe_load(open(f)) or {}
+  bucket = os.environ["PHASE_ID"]  # "design" — the bucket key, NOT "design-document"
+  if "phase_summaries" not in d or bucket not in d["phase_summaries"]:
+      raise SystemExit(f"FAIL: phase_summaries.{bucket} not found in {f}")
+  d["phase_summaries"][bucket]["return_contract"] = {
+      "schema_version": 1,
+      "phase": "design-document",  # lifecycle step name per #251 — NOT the bucket key "design"
+      "status": os.environ["STATUS"],
+      "design_issue_url": os.environ["ISSUE_URL"],
+      "issue_number": int(os.environ["ISSUE_NUM"]),
+      "design_section_present": os.environ["SECTION_PRESENT"].lower() == "true",
+      "key_decisions": json.loads(os.environ["KEY_DECISIONS"]),
+      "open_questions": json.loads(os.environ["OPEN_QUESTIONS"]),
+      "tbd_count": int(os.environ["TBD_COUNT"]),
+  }
+  yaml.dump(d, open(f, "w"), default_flow_style=False, allow_unicode=True)
+  '
+
+  # Step 3: orchestrator read helper — reads from 'design' bucket (NOT 'design-document').
+  STATE_FILE_DD="$STATE_FILE_DD" CONTRACT_JSON_DD="$CONTRACT_JSON_DD" python3 -c '
+  import os, json, yaml
+  d = yaml.safe_load(open(os.environ["STATE_FILE_DD"]))
+  # Read from bucket key "design" — the contract inside has phase="design-document"
+  rc = (d.get("phase_summaries", {}).get("design") or {}).get("return_contract")
+  if not rc:
+      raise SystemExit("FAIL: phase_summaries.design.return_contract is missing")
+  if rc.get("phase") != "design-document":
+      raise SystemExit(f"FAIL: expected phase=design-document, got {rc.get(\"phase\")}")
+  json.dump(rc, open(os.environ["CONTRACT_JSON_DD"], "w"))
+  '
+
+  # Step 4: orchestrator validator.
+  node "${SCRIPT_DIR}/validate-return-contract.js" "$CONTRACT_JSON_DD"
+
+  echo "  e2e PASS: design-document subagent → state-file (bucket: design) → orchestrator-read → validator pipeline works"
+  ```
+
+- [ ] **Step 3: Run the e2e test — verify 2 PASS lines**
+
+  Run:
+  ```bash
+  bash hooks/scripts/validate-return-contract.e2e.sh
+  ```
+  Expected output includes:
+  ```
+    e2e PASS: subagent → state-file → orchestrator-read → validator pipeline works
+    e2e PASS: design-document subagent → state-file (bucket: design) → orchestrator-read → validator pipeline works
+  ```
+  Expected exit code: 0
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  cd /Users/weee/Dev/feature-flow/.worktrees/design-document-pattern-b-e886
+  git add hooks/scripts/validate-return-contract.e2e.sh
+  git commit -m "test(e2e): add design-document contract round-trip covering bucket/step-name distinction (#251)"
+  ```
+</task>
+
+<task id="7" status="pending">
+### Task 7: Run #253 measurement and capture context percentage
+
+**Files:**
+- Read-only: session context logs (no files modified in this task)
+- Create: `.feature-flow/design/measurement-result-253.txt` (session-local, gitignored)
+
+**Context:** Issue #253 is the per-phase context-contributor instrumentation requirement. The measurement must confirm that Pattern B saves ≥5% of orchestrator context versus a pre-#262 baseline. If <5%, the conversion fails the per-phase decision rule and must be aborted.
+
+**Acceptance criteria:**
+- [ ] `[MANUAL]` Measurement result file exists and contains a percentage — measured by: `test -f .feature-flow/design/measurement-result-253.txt && grep -c "%" .feature-flow/design/measurement-result-253.txt` outputs `1`
+- [ ] `[MANUAL]` If the percentage is <5%, a decision is documented: either abort with rationale or proceed with documented exemption — measured by: file content includes either `PASS (>=5%)` or `ABORT (<5%)` keyword
+
+**Steps:**
+
+- [ ] **Step 1: Review the #253 measurement methodology**
+
+  Run:
+  ```bash
+  gh issue view 253 --repo $(git remote get-url origin | sed 's/.*github.com[:/]//' | sed 's/\.git$//') | head -100
+  ```
+  Note the exact instrumentation steps required.
+
+- [ ] **Step 2: Run comparison against a pre-#262 baseline session**
+
+  Per #253's methodology: compare orchestrator context token count for a representative lifecycle with Pattern B active vs. the baseline (pre-#251 inline skill invocation).
+
+  If #253's tooling is not yet deployed (likely — #251 is the prerequisite), use a proxy measurement:
+  - Estimate the size of content that would have been loaded inline (design-document/SKILL.md + ~3 Explore agent return payloads in orchestrator context).
+  - Document the estimate with a note: "Instrumentation not yet deployed (#253); estimate based on file sizes."
+
+  Run:
+  ```bash
+  wc -c skills/design-document/SKILL.md
+  # Estimate: 3 Explore agents × ~2KB average return = ~6KB
+  # design-document/SKILL.md = ~X KB
+  # Total inline cost estimate: ~(X + 6) KB
+  # Pattern B orchestrator sees: ~1KB (contract only)
+  # Savings estimate: ((X + 6 - 1) / (X + 6)) * 100 %
+  ```
+
+- [ ] **Step 3: Document the result**
+
+  Write `.feature-flow/design/measurement-result-253.txt`:
+  ```
+  Measurement date: 2026-05-02
+  Methodology: [exact or proxy]
+  Pre-Pattern-B orchestrator cost: [N tokens / KB]
+  Post-Pattern-B orchestrator cost: [N tokens / KB]
+  Estimated savings: [X%]
+  Decision: PASS (>=5%) | ABORT (<5%) — [rationale if ABORT]
+  ```
+
+  If ABORT: do NOT proceed to merge. Open a follow-up on #251 documenting why the threshold was not met.
+
+- [ ] **Step 4: Proceed only if PASS**
+
+  If the file contains `PASS`, continue to the PR. If `ABORT`, stop and surface to the user.
+</task>
+
+## Open Questions
+
+1. **#253 measurement tooling availability:** Is the per-phase instrumentation from issue #253 deployed? If not, Task 7 must use a proxy estimate. The plan assumes proxy is acceptable but the decision rule (≥5%) still applies. If proxy cannot be computed, Task 7 becomes a manual judgment call — surface to user before proceeding.
+
+2. **`findings_path` JSON leniency:** The Explore agent return format is `{area: string, findings: string[]}` per `skills/design-document/SKILL.md:46-49`. The format is controlled by the orchestrator's own dispatch prompt so drift is unlikely, but if a real session fails on malformed findings JSON, the `findings_path` branch in Step 1 should use lenient parsing (extract `area` + `findings` keys, ignore extras) rather than strict shape validation.
+
+</plan>

--- a/hooks/scripts/fixtures/valid-design-document.json
+++ b/hooks/scripts/fixtures/valid-design-document.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "phase": "design-document",
+  "status": "success",
+  "design_issue_url": "https://github.com/uta2000/feature-flow/issues/251",
+  "issue_number": 251,
+  "design_section_present": true,
+  "key_decisions": [
+    "Pattern B: hoist Explore fanout to orchestrator + dispatch consolidator subagent",
+    "schema_version 1 for contract (independent of state-file schema_version 2)",
+    "Inline-fallback target is pre-#251 inline Skill() (Interactive/Express form)"
+  ],
+  "open_questions": [],
+  "tbd_count": 0
+}

--- a/hooks/scripts/validate-return-contract.e2e.sh
+++ b/hooks/scripts/validate-return-contract.e2e.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
-# End-to-end test for the verify-plan-criteria Pattern A pipeline (#251).
+# End-to-end test for the subagent-driven phase architecture pipelines (#251).
 #
-# Simulates the full subagent → state file → orchestrator validation flow:
-#   1. Create a fake in-progress state file matching Task 1's schema (4 fixed
-#      phase_summaries buckets: brainstorm, design, plan, implementation).
-#   2. Run the same python3 helper that skills/verify-plan-criteria/SKILL.md
-#      Step 7 uses, with PHASE_ID=plan (the bucket — NOT the lifecycle step).
-#   3. Run the same orchestrator-side read python3 helper that
-#      skills/start/SKILL.md "Verify Plan Criteria — Pattern A Dispatch" uses
-#      to extract phase_summaries.plan.return_contract into a JSON file.
-#   4. Run hooks/scripts/validate-return-contract.js against the JSON file.
+# Two round-trips are exercised:
+#   Pattern A — verify-plan-criteria (PR #262, Wave 3 phase 1):
+#     subagent writes contract to phase_summaries.plan.return_contract,
+#     orchestrator reads + validates.
+#   Pattern B — design-document (Wave 3 phase 3):
+#     consolidator subagent writes contract to phase_summaries.design.return_contract,
+#     orchestrator reads + validates.
 #
-# Exit 0 means the entire pipeline works. Exit 1 means a regression.
+# Both round-trips use:
+#   - the same in-progress state file (4 fixed phase_summaries buckets)
+#   - PHASE_ID = bucket key (e.g. "plan", "design"), NOT the lifecycle step name
+#   - contract `phase` = lifecycle step name (e.g. "verify-plan-criteria", "design-document")
+#   - validator looks up schema by obj.phase
+#
+# Exit 0 means both pipelines work. Exit 1 means a regression.
 #
 # Run: bash hooks/scripts/validate-return-contract.e2e.sh
 
@@ -90,4 +94,57 @@ json.dump(rc, open(os.environ["CONTRACT_JSON"], "w"))
 # Step 4: orchestrator validator.
 node "${SCRIPT_DIR}/validate-return-contract.js" "$CONTRACT_JSON"
 
-echo "  e2e PASS: subagent → state-file → orchestrator-read → validator pipeline works"
+echo "  e2e PASS (verify-plan-criteria Pattern A): subagent → state-file → orchestrator-read → validator pipeline works"
+
+# ----------------------------------------------------------------------------
+# Pattern B round-trip — design-document (Wave 3 phase 3, #251)
+# Same shape as Pattern A but writes to the `design` bucket and validates
+# against the design-document SCHEMAS entry.
+# ----------------------------------------------------------------------------
+
+DD_CONTRACT_JSON="/tmp/ff-return-contract-${SLUG}-dd.json"
+trap 'rm -f "$STATE_FILE" "$CONTRACT_JSON" "$DD_CONTRACT_JSON"' EXIT
+
+# Step 5 (Pattern B): consolidator subagent writes design-document return
+# contract to the `design` bucket. Mirrors the Step 8 helper in
+# skills/design-document/SKILL.md exactly (PHASE_ID=design bucket key;
+# contracts `phase` field hardcoded to the lifecycle step name `design-document`).
+F="$STATE_FILE" PHASE_ID="design" STATUS="success" \
+DESIGN_URL="https://github.com/uta2000/feature-flow/issues/251" \
+ISSUE_NUM="251" PRESENT="true" \
+DECISIONS='["Pattern B: hoist + consolidator","Inline-fallback target is bare Skill()"]' \
+QUESTIONS='[]' TBD="0" python3 -c '
+import os, json, yaml
+f = os.environ["F"]
+d = yaml.safe_load(open(f)) or {}
+bucket = os.environ["PHASE_ID"]
+if "phase_summaries" not in d or bucket not in d["phase_summaries"]:
+    raise SystemExit(f"FAIL: phase_summaries.{bucket} not found in {f}")
+d["phase_summaries"][bucket]["return_contract"] = {
+    "schema_version": 1,
+    "phase": "design-document",  # lifecycle step name per #251 — NOT the bucket key
+    "status": os.environ["STATUS"],
+    "design_issue_url": os.environ["DESIGN_URL"],
+    "issue_number": int(os.environ["ISSUE_NUM"]),
+    "design_section_present": os.environ["PRESENT"].lower() == "true",
+    "key_decisions": json.loads(os.environ["DECISIONS"]),
+    "open_questions": json.loads(os.environ["QUESTIONS"]),
+    "tbd_count": int(os.environ["TBD"]),
+}
+yaml.dump(d, open(f, "w"), default_flow_style=False, allow_unicode=True)
+'
+
+# Step 6 (Pattern B): orchestrator read helper extracts design bucket contract.
+STATE_FILE="$STATE_FILE" DD_CONTRACT_JSON="$DD_CONTRACT_JSON" python3 -c '
+import os, json, yaml
+d = yaml.safe_load(open(os.environ["STATE_FILE"]))
+rc = (d.get("phase_summaries", {}).get("design") or {}).get("return_contract")
+if not rc:
+    raise SystemExit("FAIL: phase_summaries.design.return_contract is missing")
+json.dump(rc, open(os.environ["DD_CONTRACT_JSON"], "w"))
+'
+
+# Step 7 (Pattern B): orchestrator validator.
+node "${SCRIPT_DIR}/validate-return-contract.js" "$DD_CONTRACT_JSON"
+
+echo "  e2e PASS (design-document Pattern B): consolidator → state-file → orchestrator-read → validator pipeline works"

--- a/hooks/scripts/validate-return-contract.js
+++ b/hooks/scripts/validate-return-contract.js
@@ -13,7 +13,19 @@ const SCHEMAS = {
     criteria_machine_verifiable: 'number',
     criteria_added_by_agent: 'number',
     tasks_missing_criteria: 'array',
-  }
+  },
+  // bucket key = 'design' (phase_summaries); step name = 'design-document' (contract phase field)
+  'design-document': {
+    schema_version: 'number',
+    phase: 'string',
+    status: 'string',
+    design_issue_url: 'string',
+    issue_number: 'number',
+    design_section_present: 'boolean',
+    key_decisions: 'array',
+    open_questions: 'array',
+    tbd_count: 'number',
+  },
 };
 
 const VALID_STATUSES = new Set(['success', 'partial', 'failed']);
@@ -48,6 +60,18 @@ function validate(phaseId, obj) {
       if (typeof item !== 'string') {
         errors.push('tasks_missing_criteria: all items must be strings');
         break;
+      }
+    }
+  }
+  if (!errors.length && phaseId === 'design-document') {
+    for (const field of ['key_decisions', 'open_questions']) {
+      if (Array.isArray(obj[field])) {
+        for (const item of obj[field]) {
+          if (typeof item !== 'string') {
+            errors.push(`${field}: all items must be strings`);
+            break;
+          }
+        }
       }
     }
   }

--- a/hooks/scripts/validate-return-contract.test.js
+++ b/hooks/scripts/validate-return-contract.test.js
@@ -99,5 +99,67 @@ test('wrong field type exits 1', () => {
   if (r.code === 0) throw new Error('expected non-zero exit for string criteria_total');
 });
 
+// design-document tests (Wave 3 phase 3 — Pattern B)
+const VALID_DD = {
+  schema_version: 1,
+  phase: 'design-document',
+  status: 'success',
+  design_issue_url: 'https://github.com/uta2000/feature-flow/issues/251',
+  issue_number: 251,
+  design_section_present: true,
+  key_decisions: ['Pattern B: hoist + consolidator'],
+  open_questions: [],
+  tbd_count: 0
+};
+
+test('design-document: valid contract exits 0', () => {
+  const p = writeFixture(VALID_DD);
+  const r = run(p);
+  if (r.code !== 0) throw new Error(`expected exit 0, got ${r.code}\n${r.stderr}`);
+});
+
+test('design-document: missing required field exits 1', () => {
+  const bad = { ...VALID_DD }; delete bad.issue_number;
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for missing issue_number');
+  if (!r.stdout.includes('missing required field')) throw new Error(`expected "missing required field" in output; got: ${r.stdout}`);
+});
+
+test('design-document: wrong field type (issue_number string) exits 1', () => {
+  const bad = { ...VALID_DD, issue_number: '251' };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for string issue_number');
+});
+
+test('design-document: design_section_present non-boolean exits 1', () => {
+  const bad = { ...VALID_DD, design_section_present: 'true' };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for non-boolean design_section_present');
+});
+
+test('design-document: key_decisions with non-string item exits 1', () => {
+  const bad = { ...VALID_DD, key_decisions: [1, 2] };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for non-string key_decisions item');
+});
+
+test('design-document: open_questions with non-string item exits 1', () => {
+  const bad = { ...VALID_DD, open_questions: [{ q: 'x' }] };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for non-string open_questions item');
+});
+
+test('design-document: partial status with tbd_count > 0 is valid', () => {
+  const partial = { ...VALID_DD, status: 'partial', tbd_count: 3 };
+  const p = writeFixture(partial);
+  const r = run(p);
+  if (r.code !== 0) throw new Error(`expected exit 0 for partial status; got ${r.code}\n${r.stderr}`);
+});
+
 console.log(`\nResults: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/skills/design-document/SKILL.md
+++ b/skills/design-document/SKILL.md
@@ -17,6 +17,16 @@ Turn brainstorming decisions into a structured, implementable design document. T
 - Before writing an implementation plan
 - When translating requirements into technical design
 
+## Optional Args (used when invoked from orchestrator dispatch)
+
+When invoked as a Pattern B consolidator subagent (per #251), the orchestrator passes these arguments so the skill can skip the hoisted-fanout step and write its structured return contract back to the lifecycle's in-progress state file:
+
+- `findings_path: <absolute-path-to-findings-json>` — when set, the skill skips Step 1's Explore-agent dispatch and reads the pre-fetched findings from this JSON file instead. The file contains the consolidated `{schema, pipeline, ui, format, code, ...}` findings produced by the orchestrator-side parallel fanout. Format: `{"agents": [{"area": string, "findings": string[]}, ...]}`.
+- `write_contract_to: <absolute-path-to-in-progress-yml>` — when set, writes the return contract to `phase_summaries.<phase_id>.return_contract` in that YAML file after Step 4 (issue body merge) completes (see Step 8 below).
+- `phase_id: <bucket-name>` — identifies which **`phase_summaries` bucket** to write into. Must be one of the four fixed buckets: `brainstorm`, `design`, `plan`, or `implementation`. If absent when `write_contract_to` is set, defaults to `design` (the bucket that contains the `design-document` lifecycle step). **Do not confuse `phase_id` with the contract's own `phase` field** — `phase_id` is the bucket key (`design`); the contract's `phase` field is the lifecycle step name (`design-document`) per #251's locked spec.
+
+All three args are optional. If `findings_path` is absent, Step 1 dispatches Explore agents as before. If `write_contract_to` is absent, Step 8 is skipped — the skill behaves identically to its inline-invocation form.
+
 ## Process
 
 ### Step 1: Gather Context
@@ -25,6 +35,8 @@ Collect the inputs needed to write the document:
 
 1. **From the conversation:** Extract all decisions made during brainstorming — scope, approach, UX flow, data model, technical choices
 2. **From the codebase and documentation:** Dispatch parallel Explore agents to gather context from multiple areas simultaneously.
+
+**Pattern B consolidator-mode early exit:** If `findings_path` is set in ARGUMENTS, the orchestrator has already executed the parallel fanout. Read the JSON at that path, treat its `agents[]` array as the unified context summary, and skip the entire `#### Parallel Context Gathering` and `#### Failure Handling` subsections below. Jump directly to `#### Consolidation`. The clarification `AskUserQuestion` at the end of Consolidation is still suppressed when `yolo: true` or `express: true` is set (existing behavior). This branch exists for the Pattern B subagent dispatch wired in `skills/start/SKILL.md` — see "Design Document — Pattern B Dispatch" in that file.
 
 #### Parallel Context Gathering
 
@@ -401,6 +413,73 @@ Recommended next steps:
 1. Run `design-verification` to check this design against the codebase
 2. Run `writing-plans` to create an implementation plan with acceptance criteria
 ```
+
+### Step 8: Write Return Contract (conditional)
+
+**Only executes if `write_contract_to` is set in the skill's ARGUMENTS.** If the arg is absent, skip this step entirely — the skill behaves identically to its pre-#251 inline form.
+
+Construct the return contract object per the locked spec from #251 (issue comment locking the contract was posted before this implementation):
+
+- `schema_version`: `1` (integer — contract schema version, NOT the in-progress state-file schema_version which is `2`)
+- `phase`: hardcoded to `"design-document"` per #251's locked contract spec — this is the lifecycle step name the validator uses to look up the schema in its registry. **Not** the `phase_id` arg value. (`phase_id` names the state-file bucket, e.g. `"design"`.)
+- `status`: one of:
+  - `"success"` — design merged into issue body, no `[TBD]` markers, all required sections written
+  - `"partial"` — design merged but `tbd_count > 0` OR one or more required sections were skipped
+  - `"failed"` — design could not be merged (issue body write failed, marker integrity check failed and append also failed)
+- `design_issue_url`: full URL of the GitHub issue containing the merged design section (e.g., `https://github.com/owner/repo/issues/N`)
+- `issue_number`: integer issue number
+- `design_section_present`: boolean — `true` if `<!-- feature-flow:design:start -->` markers were merged into the issue body in Step 4 (either replaced existing markers or appended new ones), `false` if Step 4's append fallback also failed
+- `key_decisions`: list of up to 5 decision strings extracted from the design (scope, approach, major design choices)
+- `open_questions`: list of unresolved question strings flagged during writing (empty list `[]` if none)
+- `tbd_count`: integer count of `[TBD]` markers in the merged design body
+
+Write the contract to the state file using this helper (mirrors the env-var passing pattern in `skills/verify-plan-criteria/SKILL.md` Step 7 — apostrophe-safe, no inline interpolation):
+
+```bash
+F="<write_contract_to value>"
+PHASE_ID="<phase_id value, default: design>"  # state-file bucket name — must be one of {brainstorm, design, plan, implementation}; design-document lives in the design bucket
+STATUS="<success|partial|failed>"
+DESIGN_URL="<full GitHub issue URL>"
+ISSUE_NUM=<integer issue number>
+PRESENT=<true|false>  # design_section_present
+DECISIONS='<json-array-string, e.g. ["decision 1","decision 2"]>'
+QUESTIONS='<json-array-string, e.g. [] or ["q1"]>'
+TBD=<integer tbd_count>
+
+[ -f "$F" ] && F="$F" PHASE_ID="$PHASE_ID" STATUS="$STATUS" DESIGN_URL="$DESIGN_URL" ISSUE_NUM="$ISSUE_NUM" PRESENT="$PRESENT" DECISIONS="$DECISIONS" QUESTIONS="$QUESTIONS" TBD="$TBD" python3 -c '
+import os, json, yaml
+f = os.environ["F"]
+d = yaml.safe_load(open(f)) or {}
+bucket = os.environ["PHASE_ID"]  # bucket name in phase_summaries (e.g. "design")
+if "phase_summaries" not in d or bucket not in d["phase_summaries"]:
+    print(f"[design-document] WARNING: phase_summaries.{bucket} not found in {f}; skipping contract write")
+else:
+    d["phase_summaries"][bucket]["return_contract"] = {
+        "schema_version": 1,
+        # The contracts `phase` field is the lifecycle STEP NAME per #251 spec
+        # (design-document), NOT the bucket key (which would be "design").
+        # The validator uses this to look up the schema in its registry.
+        "phase": "design-document",
+        "status": os.environ["STATUS"],
+        "design_issue_url": os.environ["DESIGN_URL"],
+        "issue_number": int(os.environ["ISSUE_NUM"]),
+        "design_section_present": os.environ["PRESENT"].lower() == "true",
+        "key_decisions": json.loads(os.environ["DECISIONS"]),
+        "open_questions": json.loads(os.environ["QUESTIONS"]),
+        "tbd_count": int(os.environ["TBD"]),
+    }
+    yaml.dump(d, open(f, "w"), default_flow_style=False, allow_unicode=True)
+    print(f"[design-document] return_contract written to {f}")
+'
+```
+
+The `[ -f "$F" ]` guard is intentional — when invoked outside a lifecycle context (e.g., in tests or one-off invocations), `write_contract_to` may point to a file that doesn't exist. In that case, log a warning and return normally — the skill's primary output (the design merge announcement from Step 4) is still valid.
+
+After writing, return the state-file path and a one-line summary as the skill's result text:
+
+`"Return contract written to <write_contract_to>. Design: status=<status>, issue #<issue_number>, decisions=<count>, tbd_count=<tbd>."`
+
+The orchestrator (Pattern B wrapper in `skills/start/SKILL.md`) reads this state-file path from the result string, loads `phase_summaries.<phase_id>.return_contract` from the YAML, and runs `hooks/scripts/validate-return-contract.js` against the loaded object before proceeding.
 
 ## Quality Rules
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -675,7 +675,12 @@ Runs inline as a Bash call paired with the TaskUpdate. The `$(cd "$(git rev-pars
 
 **YOLO Model Routing (CRITICAL):** In YOLO mode, brainstorming and design document phases MUST be dispatched as `Task` calls with explicit `model` params — not as inline `Skill` calls. This gives full per-phase model control regardless of the orchestrator's model. Planning is also dispatched as a `Task` with `model: "sonnet"`.
 
-**Pattern A subagent dispatch (CRITICAL — applies in ALL modes, not just YOLO):** Some lifecycle phases are dispatched as `Task()` subagents per #251's subagent-driven phase architecture, regardless of mode. These dispatches are for **context isolation** (the orchestrator never sees the skill's intermediate work — only a structured return contract written to the in-progress state file), not for model routing. Currently converted: `verify-plan-criteria` (see "Verify Plan Criteria — Pattern A Dispatch" subsection below). Future conversions: `merge-prs`, `design-document`, `verify-acceptance-criteria`, `code-review`, `implementation` per #251's conversion order. Each Pattern A phase has its own wrapper subsection documenting the dispatch shape, return-contract validation, and inline-fallback path. **In Express and Interactive modes, Pattern A still applies** — the skill being wrapped (`verify-plan-criteria` etc.) does not require user interaction, so subagent isolation is safe in all modes.
+**Subagent dispatch patterns A and B (CRITICAL — applies in ALL modes, not just YOLO):** Some lifecycle phases are dispatched as `Task()` subagents per #251's subagent-driven phase architecture, regardless of mode. These dispatches are for **context isolation** (the orchestrator never sees the skill's intermediate work — only a structured return contract written to the in-progress state file), not for model routing. Two patterns are in use:
+
+- **Pattern A (wrap):** orchestrator dispatches one Task subagent that invokes the phase skill and returns a structured contract. Used for phases that do NOT internally fan out subagents.
+- **Pattern B (hoist + consolidator):** orchestrator dispatches the parallel fanout itself (subagents cannot dispatch sub-subagents per #251 Q1), then dispatches a single consolidator subagent that ingests fanout results, runs the rest of the skill, and returns a structured contract. Used for phases that DO internally fan out.
+
+Currently converted: `verify-plan-criteria` (Pattern A — see "Verify Plan Criteria — Pattern A Dispatch" subsection below), `design-document` (Pattern B — see "Design Document — Pattern B Dispatch" subsection below). Skipped by design analysis: `merge-prs` (no orchestrator-side benefit; see issue #251 comment). Future conversions: `verify-acceptance-criteria`, `code-review`, `implementation` per #251's conversion order. Each converted phase has its own wrapper subsection documenting the dispatch shape, return-contract validation, and inline-fallback path. **In Express and Interactive modes, Pattern A and Pattern B still apply** — the skills being wrapped do not require user interaction at the points where dispatch happens, so subagent isolation is safe in all modes.
 
 **Why:** The `Skill` tool has no `model` parameter — it inherits the parent model. The `Task` tool has an explicit `model` parameter. In YOLO mode there is no user interaction, so running skills inside a Task subagent works identically to running them inline. The `/model` command must NEVER be used — it writes to `~/.claude/settings.json` (a global config file) and affects all other terminal windows and tmux panes.
 
@@ -685,9 +690,9 @@ YOLO mode invocations:
 Task(subagent_type: "general-purpose", model: "opus", description: "YOLO brainstorming",
      prompt: "Invoke Skill(skill: 'superpowers:brainstorming', args: 'yolo: true. scope: [scope]. [context args]'). Return the complete brainstorming output including all self-answered design decisions.")
 
-# Design document — Opus for architectural decisions
-Task(subagent_type: "general-purpose", model: "opus", description: "YOLO design document",
-     prompt: "Invoke Skill(skill: 'feature-flow:design-document', args: 'yolo: true. scope: [scope]. [context args]'). Return the design document path and key decisions.")
+# Design document — Pattern B (hoist + consolidator). See "Design Document — Pattern B Dispatch" subsection below for the full dispatch shape.
+# (The pre-#251 single-Task wrapper at this location was latently broken: subagents cannot dispatch sub-subagents,
+# so the inner Explore fanout inside design-document silently failed. Pattern B fixes this.)
 
 # Implementation planning — Sonnet for structured task decomposition
 Task(subagent_type: "general-purpose", model: "sonnet", description: "YOLO implementation plan",
@@ -749,18 +754,112 @@ The inline path runs the existing skill with no `write_contract_to` arg — Step
      measurement (per #253) confirms ≥5% orchestrator context reduction. The wrapper itself stays;
      only the fallback safety net is sunset. -->
 
-**Interactive/Express mode** continues to use inline `Skill` calls for **brainstorming and design-document** (unchanged — these inherit the parent model, which should be Opus at session start). This applies to model-routing-driven dispatches only — Pattern A subagent dispatches (e.g. `verify-plan-criteria`, see "Pattern A subagent dispatch" CRITICAL block above) still use `Task()` in Interactive/Express modes because their rationale is context isolation, not model routing.
+### Design Document — Pattern B Dispatch
+
+**Note:** INLINE-FALLBACK IS A ROLLOUT-ONLY FEATURE.
+<!-- feature-flow vNEXT+1 removes inline-fallback once two consecutive successful real-session uses are observed. -->
+
+**Applies in ALL modes** (YOLO, Express, Interactive — see the "Subagent dispatch patterns A and B" CRITICAL block above). `design-document` is the first lifecycle phase converted to Pattern B subagent dispatch (per issue #251). Because the skill internally fans out 3-4 Explore agents (which subagents cannot do per #251 Q1), the orchestrator hoists the fanout to itself, then dispatches a single consolidator subagent that runs the rest of the skill (Steps 2-7) in isolation. The orchestrator never sees the consolidator's intermediate work — only the validated return contract.
+
+**Sub-step 1 — Hoisted parallel Explore fanout (orchestrator-side):**
+
+The orchestrator dispatches 3-4 Explore agents in parallel (single message), one per area. Models per #251: `model: "haiku"` (cheap, parallelizable, structured findings).
+
+```
+# Hoisted from skills/design-document/SKILL.md Step 1
+Task(subagent_type: "Explore", model: "haiku", description: "Format patterns",
+     prompt: "Read existing design docs in docs/plans/ and extract document structure, section patterns, and conventions. Read-only. Return JSON: {area: 'format', findings: [string, ...]}.")
+
+Task(subagent_type: "Explore", model: "haiku", description: "Stack & dependencies",
+     prompt: "Examine dependency files (package.json, config files), project structure, and tech stack conventions. Return JSON: {area: 'stack', findings: [string, ...]}.")
+
+Task(subagent_type: "Explore", model: "haiku", description: "Relevant code",
+     prompt: "Search for and read source files related to the feature being designed. Feature description: <inherited from lifecycle context>. Return JSON: {area: 'code', findings: [string, ...]}.")
+
+# Documentation agent (conditional — only if .feature-flow.yml has context7 field, Context7 MCP is available, and no documentation lookup ran earlier)
+Task(subagent_type: "Explore", model: "haiku", description: "Documentation (Context7)",
+     prompt: "Query Context7 libraries from .feature-flow.yml `context7` field for current patterns the design should follow. Return JSON: {area: 'docs', findings: [string, ...]}.")
+```
+
+**Sub-step 2 — Consolidate findings into a JSON file** (so the consolidator subagent can read them via `findings_path`):
+
+```bash
+BASE_REPO=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+SLUG=<slug-from-session-context>
+FINDINGS="/tmp/ff-design-findings-${SLUG}.json"
+
+# Collect each Explore agent's structured return into a single JSON file
+python3 -c "
+import json
+agents = [<list of {area, findings} dicts collected from the parallel Task() returns above>]
+json.dump({'agents': agents}, open('${FINDINGS}', 'w'))
+"
+```
+
+**Sub-step 3 — Consolidator dispatch:**
+
+```
+ISSUE=<linked-issue-number>
+STATE_FILE="${BASE_REPO}/.feature-flow/handoffs/in-progress-${SLUG}.yml"
+
+Task(
+  subagent_type: "general-purpose",
+  model: "sonnet",
+  description: "design-document Pattern B consolidator",
+  prompt: "Invoke Skill(skill: 'feature-flow:design-document', args: 'yolo: true. scope: [scope]. issue: ${ISSUE}. design_issue: ${ISSUE}. findings_path: ${FINDINGS}. write_contract_to: ${STATE_FILE}. phase_id: design'). Return the state-file path and a one-line summary of the contract."
+)
+```
+
+**Why `phase_id: design` (not `design-document`):** `phase_id` names the **state-file bucket** in `phase_summaries` — one of the four fixed keys (`brainstorm`, `design`, `plan`, `implementation`). The `design-document` lifecycle step lives in the `design` bucket. The contract's own `phase` field stays `"design-document"` per #251's locked spec. Two distinct concepts, same word "phase" — don't confuse them. (This bug bit PR #262 self-review for verify-plan-criteria; same trap applies here.)
+
+**Why `model: "sonnet"` for the consolidator:** design-document Steps 2-7 do non-trivial writing (synthesizing brainstorm decisions + Explore findings into structured Markdown sections, then merging into the GitHub issue body). Sonnet handles the writing well. Haiku is too brittle for cross-section coherence; opus is over-spec for structured Markdown synthesis where the inputs are already gathered.
+
+**Why `model: "haiku"` for the Explore fanout:** each agent's job is a focused read-and-summarize; haiku is the cost-optimal choice for parallel structured retrieval. Matches the existing design-document skill's recommendation.
+
+**Post-dispatch sequence (orchestrator-side):**
+
+1. **Read state file** and extract `phase_summaries.design.return_contract`:
+   ```bash
+   python3 -c "import json, yaml; d = yaml.safe_load(open('${STATE_FILE}')); rc = (d.get('phase_summaries', {}).get('design') or {}).get('return_contract'); json.dump(rc, open('/tmp/ff-return-contract-${SLUG}.json','w')) if rc else None; print('missing' if not rc else 'ok')"
+   ```
+   If output is `missing` → trigger **inline-fallback** (case 3 below).
+2. **Validate the contract:**
+   ```bash
+   node hooks/scripts/validate-return-contract.js /tmp/ff-return-contract-${SLUG}.json
+   ```
+   Exit 0 → proceed. Non-zero → trigger **inline-fallback** (case 4 below).
+3. **Proceed to next lifecycle step** (Design verification / Implementation plan).
+
+**Inline-fallback path** (rollout-only — four failure cases):
+
+| Case | Trigger | Announce | Next |
+|------|---------|----------|------|
+| 1 | One or more Explore agents fail/timeout AND the failure leaves <2 successful agents | `design-document Pattern B: Explore fanout failed (<reason>). Falling back to inline Skill().` | Run inline `Skill(skill: "feature-flow:design-document", args: "yolo: true. scope: <scope>. issue: <N>")` (no `findings_path` — the skill runs its own Step 1) |
+| 2 | Consolidator `Task()` dispatch fails (timeout, tool error, refusal) | `design-document Pattern B: consolidator dispatch failed (<reason>). Falling back to inline Skill().` | Same inline invocation |
+| 3 | Consolidator completes but `return_contract` field is null/absent in state file | `design-document Pattern B: consolidator did not write return_contract. Falling back to inline Skill().` | Same inline invocation |
+| 4 | `validate-return-contract.js` exits non-zero | `design-document Pattern B: contract validation failed (<error from validator>). Falling back to inline Skill().` | Same inline invocation |
+
+**The inline-fallback target is the bare `Skill()` form (Interactive/Express equivalent), NOT the pre-#251 YOLO Task() wrapper at line ~688.** The pre-#251 wrapper is latently broken — it dispatched `feature-flow:design-document` inside a `general-purpose` subagent which then attempted recursive Explore fanout (forbidden per #251 Q1). The bare `Skill()` invocation runs in the orchestrator's own context where the Explore fanout works.
+
+<!-- SUNSET NOTE: feature-flow vNEXT+1 removes this inline-fallback table and the four failure-case
+     handlers once two consecutive successful real-session uses of Pattern B are observed and the
+     measurement (per #253) confirms ≥5% orchestrator context reduction. The wrapper itself stays;
+     only the fallback safety net is sunset. -->
+
+**Interactive/Express mode** continues to use inline `Skill` calls for **brainstorming** (unchanged — inherits the parent model, which should be Opus at session start). `design-document` now uses Pattern B in all modes (the YOLO Task() wrapper at line ~688 is replaced by the Pattern B sub-steps above; the Interactive/Express bare Skill() invocations below are the inline-fallback path only). This applies to model-routing-driven dispatches only — Pattern A and Pattern B subagent dispatches still use `Task()` in Interactive/Express modes because their rationale is context isolation, not model routing.
 
 ```
 Skill(skill: "superpowers:brainstorming", args: "yolo: true. scope: [scope]. [original args]")
-Skill(skill: "feature-flow:design-document", args: "yolo: true. scope: [scope]. [original args]")
+# Note: design-document is dispatched via Pattern B above. The bare Skill() form below is the inline-fallback only.
+# Skill(skill: "feature-flow:design-document", args: "yolo: true. scope: [scope]. [original args]")  -- fallback path
 ```
 
-**Express Propagation:** When Express mode is active, prepend `express: true. scope: [scope].` to the `args` parameter of every `Skill` invocation. Express inherits all YOLO auto-selection overrides — skills that check for `yolo: true` should also check for `express: true` and behave the same way (auto-select decisions). The only difference is at the orchestrator level where checkpoints are shown instead of suppressed. Express mode uses inline `Skill` calls (not Task dispatch) to preserve the user's ability to interact at checkpoints:
+**Express Propagation:** When Express mode is active, prepend `express: true. scope: [scope].` to the `args` parameter of every `Skill` invocation. Express inherits all YOLO auto-selection overrides — skills that check for `yolo: true` should also check for `express: true` and behave the same way (auto-select decisions). The only difference is at the orchestrator level where checkpoints are shown instead of suppressed. Express mode uses inline `Skill` calls (not Task dispatch) for the brainstorming phase to preserve the user's ability to interact at checkpoints:
 
 ```
 Skill(skill: "superpowers:brainstorming", args: "express: true. scope: [scope]. [original args]")
-Skill(skill: "feature-flow:design-document", args: "express: true. scope: [scope]. [original args]")
+# Note: design-document is dispatched via Pattern B above. The bare Skill() form below is the inline-fallback only.
+# Skill(skill: "feature-flow:design-document", args: "express: true. scope: [scope]. [original args]")  -- fallback path
 ```
 
 For inline steps (CHANGELOG generation, self-review, code review, study existing patterns), the mode flag is already in the conversation context — no explicit propagation is needed.
@@ -803,7 +902,7 @@ Skill(skill: "feature-flow:verify-acceptance-criteria", args: "plan_file: /abs/p
 
 - **Brainstorm phase boundary** (after `superpowers:brainstorming` returns): set `phase_summaries.brainstorm.completed: true`, populate `key_decisions` with up to 5 string entries pulled from the brainstorming output (scope, approach, major design choices). In fast-track mode this phase is skipped — leave `completed: false`.
 
-- **Design phase boundary** (after `feature-flow:design-document` returns, or after `feature-flow:design-verification` returns in fast-track mode where the issue body is the design): set `phase_summaries.design.completed: true`, set `issue_url` to the GitHub issue URL of the design issue, and populate `key_decisions` with up to 5 design choices.
+- **Design phase boundary** (after `feature-flow:design-document` returns, or after `feature-flow:design-verification` returns in fast-track mode where the issue body is the design): set `phase_summaries.design.completed: true`, set `issue_url` to the GitHub issue URL of the design issue, and populate `key_decisions` with up to 5 design choices. **Pattern B note:** when design-document is invoked via the Pattern B wrapper (the default in all modes), the consolidator subagent has already written `phase_summaries.design.return_contract` (with status, design_issue_url, key_decisions, etc.). The orchestrator's phase-boundary write at this point updates the bucket's other fields (`completed`, `issue_url`, `key_decisions`) without overwriting `return_contract`.
 
 - **Plan phase boundary** (after `superpowers:writing-plans` returns): set `phase_summaries.plan.completed: true`, set `plan_path` to the absolute path of the saved plan markdown file, and populate `open_questions` with any unresolved questions surfaced during planning (empty list if none).
 
@@ -841,7 +940,7 @@ If the in-progress file does not exist (initial write failed), skip phase-bounda
 | Brainstorm requirements | `superpowers:brainstorming` | Decisions on scope, approach, UX. **For Feature and Major Feature scopes:** brainstorming includes the design preferences preamble — captures or loads project-wide design preferences before feature-specific questions begin. See `references/orchestration-overrides.md` → "Design Preferences Preamble". |
 | Spike / PoC | `feature-flow:spike` | Confirmed/denied assumptions |
 | Documentation lookup | No skill — inline step (see below) | Current patterns from official docs injected into context |
-| Design document | `feature-flow:design-document` | GitHub issue body (between `<!-- feature-flow:design:start -->` markers) **Context capture:** After the design document is written to the issue body, write key scope decisions, approach choices, and rejected alternatives to `.feature-flow/design/design-decisions.md` (append to the existing template — do not overwrite). |
+| Design document | `feature-flow:design-document` (invoked via Pattern B dispatch — orchestrator-side parallel Explore fanout with `model: "haiku"` + consolidator `Task()` with `model: "sonnet"`; structured return contract written to state file at `phase_summaries.design.return_contract`; inline-fallback path retained for rollout — see **Design Document — Pattern B Dispatch** section above) | GitHub issue body (between `<!-- feature-flow:design:start -->` markers); return contract validated via `hooks/scripts/validate-return-contract.js`. **Context capture:** After the design document is written to the issue body, write key scope decisions, approach choices, and rejected alternatives to `.feature-flow/design/design-decisions.md` (append to the existing template — do not overwrite). |
 | Study existing patterns | No skill — inline step (see below) | Understanding of codebase conventions for the areas being modified |
 | Design verification | `feature-flow:design-verification` | Blockers/gaps identified and fixed **Context capture:** After verification completes, write the blockers found and their resolutions to `.feature-flow/design/verification-results.md` (append to the existing template — do not overwrite). Include the verification score summary and any design changes required. |
 | Create issue | `feature-flow:create-issue` | GitHub issue URL. **If an issue number was detected in Step 1**, pass it to create-issue as the `issue` context — the skill will update the existing issue instead of creating a new one. |


### PR DESCRIPTION
## Summary

Wave 3 **phase 3** of #251's subagent-driven phase architecture. `feature-flow:design-document` is now invoked via **Pattern B** (orchestrator-side parallel Explore fanout with `model: "haiku"` + consolidator subagent with `model: "sonnet"`). Replaces the pre-#251 YOLO `Task()` wrapper which was latently broken (subagents cannot dispatch sub-subagents per #251 Q1, so the inner Explore fanout silently failed and the design doc was written without codebase context).

This sets the **Pattern B precedent** for the 3 remaining Pattern B conversions (`verify-acceptance-criteria`, `code-review`, `implementation`).

## What changed

- **`skills/start/SKILL.md`** — new "Design Document — Pattern B Dispatch" subsection (parallel to verify-plan-criteria's Pattern A wrapper at L697-751); replaced YOLO Task() wrapper at L688-690 with Pattern B reference; updated CRITICAL routing block (L683) to reflect 2 converted phases + skipped merge-prs; updated Skill Mapping row; updated Design phase boundary write note to clarify return_contract preservation.
- **`skills/design-document/SKILL.md`** — added Optional Args section documenting `findings_path`, `write_contract_to`, `phase_id`. Added Step 1 early-exit branch (when `findings_path` is set, skip Explore fanout and read pre-fetched findings). Added Step 8 contract-write helper (mirrors verify-plan-criteria/SKILL.md Step 7).
- **`hooks/scripts/validate-return-contract.js`** — added `design-document` SCHEMAS entry (9 fields per #251 locked contract). Added per-item string validation for `key_decisions` and `open_questions` arrays.
- **`hooks/scripts/validate-return-contract.test.js`** — 7 new design-document tests (15 total pass).
- **`hooks/scripts/validate-return-contract.e2e.sh`** — added Pattern B round-trip (consolidator → state-file → orchestrator-read → validator). Updated banner comment.
- **`hooks/scripts/fixtures/valid-design-document.json`** — new fixture.
- **`docs/plans/2026-05-02-design-document-pattern-b-conversion.md`** — implementation plan, 7 tasks, 21 acceptance criteria (18 machine-verifiable).
- **`.changelogs/2026-05-02-design-document-pattern-b-conversion.md`** — changelog fragment.

## Pattern B precedent

This is the **first Pattern B implementation**. The shape established here will be reused for:
- `verify-acceptance-criteria` (Wave 3 phase 4)
- `code-review` (Wave 3 phase 5)
- `implementation` (Wave 3 phase 6)

Key Pattern B invariants to mirror in those PRs:
1. **Hoist** the parallel fanout to `start/SKILL.md` (orchestrator dispatches Task() per agent — subagents can't).
2. **Consolidate** findings to a JSON file at `/tmp/ff-<phase>-findings-<slug>.json`.
3. **Dispatch** a single `Task(subagent_type: "general-purpose", model: "sonnet", ...)` consolidator that invokes the original skill with a `findings_path` arg (skill skips its own Step 1 fanout).
4. **Validate** the return contract via `hooks/scripts/validate-return-contract.js` after the consolidator returns.
5. **Inline-fallback** to the bare `Skill()` form (NOT the pre-#251 YOLO Task() wrapper, which is latently broken for any internally-fanning-out skill).
6. **`phase_id` is the bucket key** (one of `brainstorm/design/plan/implementation`); contract `phase` is the lifecycle step name. Two distinct concepts that both use the word "phase" — this bug bit PR #262 self-review and was caught here proactively (search for "bucket-vs-phase" in this PR's diff).

## Inline-fallback (rollout-only with explicit sunset)

Four failure cases (one more than Pattern A — adds Explore-fanout failure):
1. Explore fanout fails with <2 successful agents → fall back to inline `Skill()`
2. Consolidator dispatch fails (timeout, tool error, refusal) → fall back
3. Consolidator returns null `return_contract` field → fall back
4. Validator exits non-zero → fall back

**vNEXT+1** removes the inline-fallback once two consecutive successful real-session uses of Pattern B are observed AND #253 measurement confirms ≥5% orchestrator context reduction.

## Phase 1 sunset progress

This very lifecycle's `verify-plan-criteria` Pattern A dispatch fired and validated successfully — **real-session use #1 of phase 1 (PR #262)**. Contract: `criteria_total: 21, criteria_machine_verifiable: 18, criteria_added_by_agent: 0, status: "success"`, validator exit 0. The phase 1 inline-fallback sunset PR can open after one more session of successful Pattern A use (the next session that runs `verify-plan-criteria` qualifies — likely Wave 3 phase 4's lifecycle).

## #253 measurement (deferred to post-merge)

Per #251's per-phase decision rule, the orchestrator-side context reduction must be measured against a pre-#262 baseline session before the inline-fallback sunsets. **This measurement is deferred to post-merge** — it requires running a real lifecycle session that exercises the new Pattern B dispatch end-to-end, then comparing against the baseline JSONLs in `~/.claude/projects/-Users-weee-Dev-feature-flow/` (multiple pre-#262 sessions exist: 18:12, 16:17, etc.). Will be posted as a comment on this PR (or on #251) once captured.

If measured reduction is <5%, the conversion fails the per-phase decision rule per #251 — in which case the sunset PR will revert this conversion rather than remove the fallback. Per-phase decision, not all-or-nothing (per #251).

## Notes for reviewer

- **Targeted design-verification:** the standard 5-domain × 8-batch fanout was deliberately skipped for this meta-architectural refactor (no data models / UI / API routes to verify against). A single targeted Explore subagent answered 6 specific blocker questions instead — saved ~50K tokens of irrelevant fanout. Findings recorded in the worktree's `.feature-flow/design/verification-results.md` (not committed).
- **Targeted code-review:** similarly skipped the full pr-review-toolkit pipeline in favor of a single high-confidence reviewer agent focused on the 6 known risk areas (bucket-vs-phase, fallback target, validator completeness, Step 1 branch, wrapper consistency, tests). Returned: "No HIGH-CONFIDENCE issues found. Recommend merge."
- **Latent bug fix:** the pre-#251 YOLO Task() wrapper for design-document at `skills/start/SKILL.md:~688` (now removed) was latently broken — recursive Explore dispatch silently failed inside the general-purpose subagent. Pattern B fixes this. There are no existing tests of the YOLO design-document path, so this was undetected.
- **Tests not in CI:** `hooks/scripts/*.test.js` + `*.e2e.sh` follow the existing pattern of being manually-runnable. Run `node hooks/scripts/validate-return-contract.test.js` and `bash hooks/scripts/validate-return-contract.e2e.sh` from the worktree.

## Test plan

- [x] All 15 unit tests pass: `node hooks/scripts/validate-return-contract.test.js`
- [x] E2E test passes (both Pattern A and Pattern B round-trips): `bash hooks/scripts/validate-return-contract.e2e.sh`
- [x] All 18 machine-verifiable acceptance criteria from the plan pass mechanically (T1: comment count ≥1; T2: validator exit 0 on valid, exit 1 on missing field; T3: 3 args + Step 8 present; T4: wrapper section + phase_id: design + 4 Explore Task()s; T5: design-document in "Currently converted" line; T6: e2e PASS for both pipelines)
- [x] Pattern A real-session use #1 captured during this lifecycle (verify-plan-criteria Pattern A fired and validator exit 0)
- [x] Targeted code-review: "No HIGH-CONFIDENCE issues found. Recommend merge."
- [ ] [POST-MERGE — Task 7] Real-session lifecycle uses dispatched design-document; #253 measurement shows ≥5% orchestrator context reduction; results posted as comment

<!-- feature-flow-metadata:v1
schema_version: 1
lifecycle_session: 2026-05-02-design-document-pattern-b-conversion
created_at: 2026-05-02T22:25:00Z
scope: feature
risk_tier: medium
issue: 251
design_issue: 251
plan_file: docs/plans/2026-05-02-design-document-pattern-b-conversion.md
acceptance_criteria_verified_at: 2026-05-02T22:25:00Z
acceptance_criteria_count: 21
risk_areas:
  - skills/start/SKILL.md
  - skills/design-document/SKILL.md
  - hooks/scripts
sibling_prs: []
depends_on_prs:
  - "#262"
remediation_log: []
-->