### PR TITLE
feat(start): convert verify-acceptance-criteria to Pattern B subagent dispatch (#251)

### DIFF
--- a/.changelogs/2026-05-03-verify-acceptance-criteria-pattern-b.md
+++ b/.changelogs/2026-05-03-verify-acceptance-criteria-pattern-b.md
@@ -1,0 +1,24 @@
+### Added — verify-acceptance-criteria Pattern B subagent dispatch (#251 Wave 3 phase 4)
+
+`feature-flow:verify-acceptance-criteria` now runs as Pattern B (hoisted task-verifier dispatch +
+consolidator subagent) when invoked from the Final Verification inline step. The orchestrator
+dispatches `feature-flow:task-verifier` directly (`model: "haiku"`) — fixing the latent recursive-dispatch
+bug where the inner `Task()` silently failed inside any wrapping subagent (per #251 Q1) — then dispatches
+a `general-purpose` consolidator (`model: "sonnet"`) that runs Steps 4-6 of the skill in isolation. The
+return contract is validated by `hooks/scripts/validate-return-contract.js` before the lifecycle proceeds.
+
+**Architectural deviation from PR #263 (`design-document` Pattern B):** the contract is written
+directly to a tmp JSON file at `/tmp/ff-verify-ac-contract-${SLUG}.json` rather than into a
+`phase_summaries` bucket on the in-progress state file. The four buckets (`brainstorm`, `design`,
+`plan`, `implementation`) are all claimed by phase-boundary writes, and the natural `implementation`
+slot would collide with the future Phase 6 (`subagent-driven-development`) Pattern B contract.
+Verify-acceptance-criteria is a verification step within the implementation phase (not a phase that
+owns a bucket), and its contract has no cross-compaction reader — so skipping the state-file
+mediation avoids the collision with no functional cost. No `schema_version` bump.
+
+**Inline-fallback** (rollout-only) is retained for four failure cases (task-verifier dispatch
+failure, consolidator dispatch failure, missing contract file, validator non-zero exit). Sunset
+target: `feature-flow vNEXT+1` after two consecutive successful real-session uses.
+
+**Per-phase decision rule (#251):** the ≥5% orchestrator-context-reduction measurement (per #253
+instrumentation) is deferred to post-merge real-session use, mirroring the explicit deferral in PR #263.

--- a/docs/plans/2026-05-03-verify-acceptance-criteria-pattern-b.md
+++ b/docs/plans/2026-05-03-verify-acceptance-criteria-pattern-b.md
@@ -1,0 +1,180 @@
+# verify-acceptance-criteria Pattern B Conversion — Implementation Plan
+
+**Date:** 2026-05-03
+**Issue:** #251 (Wave 3 phase 4)
+**Status:** Ready for implementation
+**Reference PR:** #263 (design-document Pattern B precedent)
+**Reference PR:** #262 (verify-plan-criteria Pattern A precedent — validator + e2e + fixtures)
+
+## Summary
+
+Convert `feature-flow:verify-acceptance-criteria` from inline-skill-with-internal-Task() to Pattern B
+subagent dispatch (per #251). The current skill internally dispatches one `feature-flow:task-verifier`
+subagent at Step 3 — which **silently fails inside a wrapping subagent** because subagents cannot
+dispatch sub-subagents (per #251 Q1). Pattern B fixes this by hoisting the task-verifier dispatch to
+the orchestrator and isolating the rest of the skill (Steps 4-5 + contract write) inside a
+consolidator subagent.
+
+**Architectural deviation from the design-document precedent: skip the state-file bucket.** Verify-acceptance-criteria does not own
+a dedicated `phase_summaries` bucket (the four buckets are `brainstorm | design | plan | implementation`,
+all already claimed by phase-boundary writes; the natural `implementation` bucket would collide with
+the future Phase 6 `subagent-driven-development` Pattern B contract). The contract is written
+directly to a tmp JSON file the orchestrator validates and then discards. No schema bump. Documented
+in the Pattern B wrapper section.
+
+## Locked return contract
+
+Per #251 (exemplar 2 in the issue body, locked before any implementation):
+
+```json
+{
+  "schema_version": 1,
+  "phase": "verify-acceptance-criteria",
+  "status": "success | partial | failed",
+  "report_path": "string (abs path to detailed pass/fail report)",
+  "pass_count": "integer",
+  "fail_count": "integer",
+  "failed_criteria": ["array of {task_id: string, criterion: string, reason: string}"]
+}
+```
+
+**Status semantics:**
+- `success` — all criteria PASS or CANNOT_VERIFY (verdict VERIFIED)
+- `partial` — at least one criterion FAIL (verdict INCOMPLETE)
+- `failed` — verifier could not run (verdict BLOCKED — broken build, missing deps)
+
+**Validator extension:** `failed_criteria` is array-of-objects, a new shape the validator does not
+currently support. Extend the validator with a typed array-of-objects check (mirrors the existing
+`tasks_missing_criteria` array-of-strings check; same hand-rolled style — no `ajv` dependency).
+
+## Tasks
+
+### Task 1 — Extend validator schema for verify-acceptance-criteria
+
+Add a SCHEMAS entry for `verify-acceptance-criteria`. Add an array-of-objects validation
+function (`checkArrayOfObjects`) that walks `failed_criteria` and verifies each item is an
+object with required string keys `task_id`, `criterion`, `reason`.
+
+**Acceptance Criteria:**
+- [ ] `hooks/scripts/validate-return-contract.js` `SCHEMAS` object contains a `'verify-acceptance-criteria'` key
+- [ ] The schema declares 7 fields: `schema_version`, `phase`, `status`, `report_path`, `pass_count`, `fail_count`, `failed_criteria`
+- [ ] Validator code includes a per-item check for `failed_criteria` array elements (each must be object with `task_id`, `criterion`, `reason` string fields)
+- [ ] Running `node hooks/scripts/validate-return-contract.js hooks/scripts/fixtures/valid-verify-acceptance-criteria.json` exits 0 (after Task 2 ships the fixture)
+
+### Task 2 — Add fixture and unit tests
+
+Create a valid fixture and extend the validator unit tests with verify-acceptance-criteria coverage.
+
+**Acceptance Criteria:**
+- [ ] File exists at `hooks/scripts/fixtures/valid-verify-acceptance-criteria.json`
+- [ ] Fixture's `phase` field is the string `"verify-acceptance-criteria"`
+- [ ] Fixture's `failed_criteria` is an empty array `[]` (success case)
+- [ ] `hooks/scripts/validate-return-contract.test.js` defines `VALID_VAC` constant with all 7 fields
+- [ ] Test "verify-acceptance-criteria: valid contract exits 0" passes
+- [ ] Test "verify-acceptance-criteria: missing required field exits 1" passes (delete `pass_count`)
+- [ ] Test "verify-acceptance-criteria: failed_criteria with non-object item exits 1" passes (item is a string)
+- [ ] Test "verify-acceptance-criteria: failed_criteria object missing task_id exits 1" passes
+- [ ] Test "verify-acceptance-criteria: partial status with non-empty failed_criteria is valid" passes
+- [ ] `node hooks/scripts/validate-return-contract.test.js` exits 0 with all tests passing
+
+### Task 3 — Modify verify-acceptance-criteria SKILL.md to support consolidator mode
+
+Add an "Optional Args" section documenting `verifier_report_path`, `write_contract_to`, and
+`phase_id` (consolidator mode). When `verifier_report_path` is set, skill skips Step 3
+(task-verifier dispatch — already done by the orchestrator) and reads the report from the path.
+When `write_contract_to` is set, the skill writes the contract to that JSON path after Step 4.
+
+**Acceptance Criteria:**
+- [ ] `skills/verify-acceptance-criteria/SKILL.md` contains an "## Optional Args" section
+- [ ] Section documents two args: `verifier_report_path`, `write_contract_to`
+- [ ] Section explicitly notes that `write_contract_to` is a JSON file path (not a state-file YAML), distinguishing this from design-document's state-file integration
+- [ ] Step 3 in the skill includes a "Pattern B consolidator-mode early exit" branch that reads the verifier report from `verifier_report_path` instead of dispatching the task-verifier subagent
+- [ ] A new "Step 6: Write Return Contract (conditional)" section exists after Step 5
+- [ ] Step 6 only executes when `write_contract_to` is set in ARGUMENTS
+- [ ] Step 6 writes contract with all 7 locked fields including `phase: "verify-acceptance-criteria"` (hardcoded — not derived from any arg)
+- [ ] Step 6 uses env-var passing (apostrophe-safe) and `python3 -c` for the JSON write
+- [ ] Step 6 emits a result string starting with `"Return contract written to <write_contract_to>."`
+
+### Task 4 — Add Pattern B wrapper to start/SKILL.md
+
+Add a new "Verify Acceptance Criteria — Pattern B Dispatch" subsection in `skills/start/SKILL.md`
+mirroring the design-document precedent at line 757. Update the Pattern A/B summary line to
+list `verify-acceptance-criteria` alongside `design-document`.
+
+**Acceptance Criteria:**
+- [ ] `skills/start/SKILL.md` contains a new section heading `### Verify Acceptance Criteria — Pattern B Dispatch`
+- [ ] Section is positioned after the existing "Design Document — Pattern B Dispatch" section
+- [ ] Section opens with the `INLINE-FALLBACK IS A ROLLOUT-ONLY FEATURE` note plus an HTML-comment SUNSET line referencing `feature-flow vNEXT+1`
+- [ ] Section includes "Sub-step 1 — Hoisted task-verifier dispatch" with explicit `model: "haiku"` and `subagent_type: "feature-flow:task-verifier"`
+- [ ] Sub-step 1's prompt instructs the task-verifier to read the plan, extract criteria, write the detailed report to `${REPORT_PATH}`, and return a short JSON summary
+- [ ] Section includes "Sub-step 2 — Consolidator dispatch" with explicit `model: "sonnet"` and `subagent_type: "general-purpose"`
+- [ ] Sub-step 2 dispatches `feature-flow:verify-acceptance-criteria` with `verifier_report_path`, `write_contract_to`, and `plan_file` args
+- [ ] Section includes a "Why skip the state-file bucket" rationale paragraph (4 fixed buckets all claimed; future Phase 6 collision; no cross-compaction reader needed)
+- [ ] Section includes a 4-row inline-fallback table covering: task-verifier dispatch failure, consolidator dispatch failure, missing contract file, validator non-zero exit
+- [ ] Inline-fallback target is the bare `Skill(skill: "feature-flow:verify-acceptance-criteria", args: "plan_file: <path>")` form
+- [ ] The line at `skills/start/SKILL.md:683` (Pattern A/B status summary) lists `verify-acceptance-criteria` as converted to Pattern B
+- [ ] The Skill Mapping row for `Verify acceptance criteria` is added (or the Final Verification step description is updated) to reference the new Pattern B Dispatch section
+
+### Task 5 — Update inline-steps.md Final Verification step to use Pattern B
+
+The verify-acceptance-criteria call site is the Final Verification inline step (`skills/start/references/inline-steps.md:489`).
+Replace the bare "Always run verify-acceptance-criteria" sentence with a reference to the new
+Pattern B wrapper section in start/SKILL.md.
+
+**Acceptance Criteria:**
+- [ ] `skills/start/references/inline-steps.md` Final Verification step (line ~489 area) explicitly references the Pattern B Dispatch section in `skills/start/SKILL.md`
+- [ ] The reference makes clear that verify-acceptance-criteria runs via Pattern B in all modes (YOLO, Express, Interactive)
+- [ ] The "Always run" semantics are preserved — the step still always invokes verify-acceptance-criteria regardless of quality-gate skip status
+
+### Task 6 — Add e2e round-trip test for Pattern B verify-acceptance-criteria pipeline
+
+Extend `hooks/scripts/validate-return-contract.e2e.sh` with a third pipeline section: build a
+contract object as the consolidator subagent would, write it directly to a tmp JSON file (no
+state-file mediation — that's the architectural deviation), and run the validator against it.
+
+**Acceptance Criteria:**
+- [ ] `hooks/scripts/validate-return-contract.e2e.sh` contains a new section header `# Pattern B round-trip — verify-acceptance-criteria`
+- [ ] Section writes a JSON contract directly to `/tmp/ff-verify-ac-contract-${SLUG}.json` (no state-file write — verify in section comment that this is intentional)
+- [ ] Section's contract has `phase: "verify-acceptance-criteria"` and all 7 locked fields
+- [ ] Section runs `node "${SCRIPT_DIR}/validate-return-contract.js" "$VAC_CONTRACT_JSON"`
+- [ ] Section emits a `e2e PASS (verify-acceptance-criteria Pattern B)` line on success
+- [ ] Trap cleanup is updated to also remove the new tmp contract file
+- [ ] `bash hooks/scripts/validate-return-contract.e2e.sh` exits 0 end-to-end (all three pipelines pass)
+
+### Task 7 — Generate CHANGELOG fragment
+
+Write a single-file changelog fragment under `.changelogs/` describing the Pattern B conversion
+and the architectural deviation (bucket-skip).
+
+**Acceptance Criteria:**
+- [ ] File exists at `.changelogs/2026-05-03-verify-acceptance-criteria-pattern-b.md`
+- [ ] Fragment includes the conversion summary (verify-acceptance-criteria → Pattern B per #251 Wave 3 phase 4)
+- [ ] Fragment notes the bucket-skip architectural deviation explicitly
+- [ ] Fragment notes the inline-fallback sunset target (vNEXT+1)
+
+## Implementation order
+
+Tasks must run sequentially:
+1. Task 1 (validator schema)
+2. Task 2 (fixture + unit tests) — depends on Task 1
+3. Task 3 (skill consolidator mode) — independent of 1/2 mechanically but logically follows
+4. Task 4 (start/SKILL.md wrapper) — depends on Tasks 1 + 3 contracts being settled
+5. Task 5 (inline-steps.md call-site update) — depends on Task 4
+6. Task 6 (e2e test) — depends on Task 1
+7. Task 7 (CHANGELOG fragment) — last
+
+## Out of scope
+
+- **Modifying `agents/task-verifier.md`** — the existing agent already does the right work
+  (read criteria, verify, report). The Pattern B wrapper provides the criteria-extraction
+  prompt directly to task-verifier rather than having the skill extract first. No changes to
+  the agent definition itself.
+- **State-file integration for verify-acceptance-criteria's contract** — explicitly rejected
+  per the bucket-skip rationale. Phase 6 (implementation) will own `phase_summaries.implementation.return_contract`.
+- **Measurement (#253)** — deferred to post-merge real-session use, per the same deferral
+  noted in PR #263. The conversion's per-phase decision rule (≥5% reduction or drop) is
+  evaluated in a follow-up iteration after at least one real-session use.
+- **Sunsetting design-document's inline-fallback** — separate PR after two real-session uses
+  of PR #263's Pattern B path, tracked in #251.
+- **Sunsetting verify-plan-criteria's inline-fallback** — separate PR; its sunset clock has
+  not yet completed (only one real-session use observed per #263's PR body).

--- a/hooks/scripts/fixtures/valid-verify-acceptance-criteria.json
+++ b/hooks/scripts/fixtures/valid-verify-acceptance-criteria.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "phase": "verify-acceptance-criteria",
+  "status": "success",
+  "report_path": "/tmp/ff-verify-ac-report-ddc1.md",
+  "pass_count": 18,
+  "fail_count": 0,
+  "failed_criteria": []
+}

--- a/hooks/scripts/validate-return-contract.e2e.sh
+++ b/hooks/scripts/validate-return-contract.e2e.sh
@@ -148,3 +148,44 @@ json.dump(rc, open(os.environ["DD_CONTRACT_JSON"], "w"))
 node "${SCRIPT_DIR}/validate-return-contract.js" "$DD_CONTRACT_JSON"
 
 echo "  e2e PASS (design-document Pattern B): consolidator → state-file → orchestrator-read → validator pipeline works"
+
+# ----------------------------------------------------------------------------
+# Pattern B round-trip — verify-acceptance-criteria (Wave 3 phase 4, #251)
+# Architectural deviation: this contract is written DIRECTLY to a tmp JSON
+# file by the consolidator subagent. There is no state-file mediation — the
+# four phase_summaries buckets (brainstorm/design/plan/implementation) are
+# all claimed and the natural `implementation` slot would collide with
+# future Phase 6 (subagent-driven-development) Pattern B. See
+# "Verify Acceptance Criteria — Pattern B Dispatch" in skills/start/SKILL.md
+# for full rationale.
+# ----------------------------------------------------------------------------
+
+VAC_CONTRACT_JSON="/tmp/ff-verify-ac-contract-${SLUG}.json"
+trap 'rm -f "$STATE_FILE" "$CONTRACT_JSON" "$DD_CONTRACT_JSON" "$VAC_CONTRACT_JSON"' EXIT
+
+# Step 8 (Pattern B): consolidator subagent writes verify-acceptance-criteria
+# return contract directly to the tmp JSON path. Mirrors the Step 6 helper
+# in skills/verify-acceptance-criteria/SKILL.md exactly (no PHASE_ID — no
+# bucket — contract `phase` field hardcoded to the lifecycle step name
+# `verify-acceptance-criteria`).
+F="$VAC_CONTRACT_JSON" STATUS="success" \
+REPORT="/tmp/ff-verify-ac-report-${SLUG}.md" \
+PASS="18" FAIL="0" FAILED='[]' python3 -c '
+import os, json
+contract = {
+    "schema_version": 1,
+    "phase": "verify-acceptance-criteria",  # lifecycle step name per #251 — there is no bucket
+    "status": os.environ["STATUS"],
+    "report_path": os.environ["REPORT"],
+    "pass_count": int(os.environ["PASS"]),
+    "fail_count": int(os.environ["FAIL"]),
+    "failed_criteria": json.loads(os.environ["FAILED"]),
+}
+json.dump(contract, open(os.environ["F"], "w"))
+'
+
+# Step 9 (Pattern B): orchestrator validator (no read-helper step — the
+# consolidator wrote directly to the tmp path, no state-file extraction).
+node "${SCRIPT_DIR}/validate-return-contract.js" "$VAC_CONTRACT_JSON"
+
+echo "  e2e PASS (verify-acceptance-criteria Pattern B): consolidator → tmp-json → validator pipeline works (no state-file)"

--- a/hooks/scripts/validate-return-contract.js
+++ b/hooks/scripts/validate-return-contract.js
@@ -26,7 +26,22 @@ const SCHEMAS = {
     open_questions: 'array',
     tbd_count: 'number',
   },
+  // Wave 3 phase 4 (#251) — Pattern B. Contract is written directly to a tmp
+  // JSON file by the consolidator subagent (no phase_summaries bucket — the
+  // four buckets are all claimed and the natural `implementation` slot will
+  // collide with future Phase 6's subagent-driven-development contract).
+  'verify-acceptance-criteria': {
+    schema_version: 'number',
+    phase: 'string',
+    status: 'string',
+    report_path: 'string',
+    pass_count: 'number',
+    fail_count: 'number',
+    failed_criteria: 'array',
+  },
 };
+
+const FAILED_CRITERIA_ITEM_FIELDS = ['task_id', 'criterion', 'reason'];
 
 const VALID_STATUSES = new Set(['success', 'partial', 'failed']);
 
@@ -72,6 +87,22 @@ function validate(phaseId, obj) {
             break;
           }
         }
+      }
+    }
+  }
+  if (!errors.length && phaseId === 'verify-acceptance-criteria' && Array.isArray(obj.failed_criteria)) {
+    for (const item of obj.failed_criteria) {
+      if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+        errors.push('failed_criteria: all items must be objects');
+        break;
+      }
+      let badField = null;
+      for (const f of FAILED_CRITERIA_ITEM_FIELDS) {
+        if (typeof item[f] !== 'string') { badField = f; break; }
+      }
+      if (badField) {
+        errors.push(`failed_criteria: each item must have string fields task_id, criterion, reason (missing or non-string: ${badField})`);
+        break;
       }
     }
   }

--- a/hooks/scripts/validate-return-contract.js
+++ b/hooks/scripts/validate-return-contract.js
@@ -101,7 +101,7 @@ function validate(phaseId, obj) {
         if (typeof item[f] !== 'string') { badField = f; break; }
       }
       if (badField) {
-        errors.push(`failed_criteria: each item must have string fields task_id, criterion, reason (missing or non-string: ${badField})`);
+        errors.push(`failed_criteria: each item must have string fields ${FAILED_CRITERIA_ITEM_FIELDS.join(', ')} (missing or non-string: ${badField})`);
         break;
       }
     }

--- a/hooks/scripts/validate-return-contract.test.js
+++ b/hooks/scripts/validate-return-contract.test.js
@@ -161,5 +161,70 @@ test('design-document: partial status with tbd_count > 0 is valid', () => {
   if (r.code !== 0) throw new Error(`expected exit 0 for partial status; got ${r.code}\n${r.stderr}`);
 });
 
+// verify-acceptance-criteria tests (Wave 3 phase 4 — Pattern B, #251)
+const VALID_VAC = {
+  schema_version: 1,
+  phase: 'verify-acceptance-criteria',
+  status: 'success',
+  report_path: '/tmp/ff-verify-ac-report-ddc1.md',
+  pass_count: 18,
+  fail_count: 0,
+  failed_criteria: []
+};
+
+test('verify-acceptance-criteria: valid contract exits 0', () => {
+  const p = writeFixture(VALID_VAC);
+  const r = run(p);
+  if (r.code !== 0) throw new Error(`expected exit 0, got ${r.code}\n${r.stderr}`);
+});
+
+test('verify-acceptance-criteria: missing required field exits 1', () => {
+  const bad = { ...VALID_VAC }; delete bad.pass_count;
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for missing pass_count');
+  if (!r.stdout.includes('missing required field')) throw new Error(`expected "missing required field" in output; got: ${r.stdout}`);
+});
+
+test('verify-acceptance-criteria: failed_criteria with non-object item exits 1', () => {
+  const bad = { ...VALID_VAC, status: 'partial', failed_criteria: ['Task 1: foo'] };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for string item in failed_criteria');
+});
+
+test('verify-acceptance-criteria: failed_criteria object missing task_id exits 1', () => {
+  const bad = { ...VALID_VAC, status: 'partial', failed_criteria: [{ criterion: 'x', reason: 'y' }] };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for failed_criteria item missing task_id');
+});
+
+test('verify-acceptance-criteria: failed_criteria object with non-string field exits 1', () => {
+  const bad = { ...VALID_VAC, status: 'partial', failed_criteria: [{ task_id: 1, criterion: 'x', reason: 'y' }] };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for non-string task_id');
+});
+
+test('verify-acceptance-criteria: partial status with non-empty failed_criteria is valid', () => {
+  const partial = {
+    ...VALID_VAC,
+    status: 'partial',
+    fail_count: 1,
+    failed_criteria: [{ task_id: 'Task 3', criterion: 'File exists at src/foo.ts', reason: 'file not found' }]
+  };
+  const p = writeFixture(partial);
+  const r = run(p);
+  if (r.code !== 0) throw new Error(`expected exit 0 for partial with valid failed_criteria; got ${r.code}\n${r.stderr}`);
+});
+
+test('verify-acceptance-criteria: failed status is valid', () => {
+  const failed_status = { ...VALID_VAC, status: 'failed' };
+  const p = writeFixture(failed_status);
+  const r = run(p);
+  if (r.code !== 0) throw new Error(`expected exit 0 for failed status; got ${r.code}\n${r.stderr}`);
+});
+
 console.log(`\nResults: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -919,7 +919,7 @@ Task(
    node hooks/scripts/validate-return-contract.js "${CONTRACT_PATH}"
    ```
    Exit 0 → proceed. Non-zero → trigger **inline-fallback** (case 4 below).
-3. **Read pass/fail counts** from the validated contract for downstream metadata-block population (`acceptance_criteria_count`, etc.). Proceed to next lifecycle step (Sync with base branch / Commit and PR).
+3. **Read pass/fail counts** from the validated contract and sum them (`pass_count + fail_count`) to derive the `acceptance_criteria_count` metadata-block field. Proceed to next lifecycle step (Sync with base branch / Commit and PR).
 
 **Inline-fallback path** (rollout-only — four failure cases):
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -680,7 +680,7 @@ Runs inline as a Bash call paired with the TaskUpdate. The `$(cd "$(git rev-pars
 - **Pattern A (wrap):** orchestrator dispatches one Task subagent that invokes the phase skill and returns a structured contract. Used for phases that do NOT internally fan out subagents.
 - **Pattern B (hoist + consolidator):** orchestrator dispatches the parallel fanout itself (subagents cannot dispatch sub-subagents per #251 Q1), then dispatches a single consolidator subagent that ingests fanout results, runs the rest of the skill, and returns a structured contract. Used for phases that DO internally fan out.
 
-Currently converted: `verify-plan-criteria` (Pattern A — see "Verify Plan Criteria — Pattern A Dispatch" subsection below), `design-document` (Pattern B — see "Design Document — Pattern B Dispatch" subsection below). Skipped by design analysis: `merge-prs` (no orchestrator-side benefit; see issue #251 comment). Future conversions: `verify-acceptance-criteria`, `code-review`, `implementation` per #251's conversion order. Each converted phase has its own wrapper subsection documenting the dispatch shape, return-contract validation, and inline-fallback path. **In Express and Interactive modes, Pattern A and Pattern B still apply** — the skills being wrapped do not require user interaction at the points where dispatch happens, so subagent isolation is safe in all modes.
+Currently converted: `verify-plan-criteria` (Pattern A — see "Verify Plan Criteria — Pattern A Dispatch" subsection below), `design-document` (Pattern B — see "Design Document — Pattern B Dispatch" subsection below), `verify-acceptance-criteria` (Pattern B — see "Verify Acceptance Criteria — Pattern B Dispatch" subsection below). Skipped by design analysis: `merge-prs` (no orchestrator-side benefit; see issue #251 comment). Future conversions: `code-review`, `implementation` per #251's conversion order. Each converted phase has its own wrapper subsection documenting the dispatch shape, return-contract validation, and inline-fallback path. **In Express and Interactive modes, Pattern A and Pattern B still apply** — the skills being wrapped do not require user interaction at the points where dispatch happens, so subagent isolation is safe in all modes.
 
 **Why:** The `Skill` tool has no `model` parameter — it inherits the parent model. The `Task` tool has an explicit `model` parameter. In YOLO mode there is no user interaction, so running skills inside a Task subagent works identically to running them inline. The `/model` command must NEVER be used — it writes to `~/.claude/settings.json` (a global config file) and affects all other terminal windows and tmux panes.
 
@@ -864,6 +864,81 @@ Skill(skill: "superpowers:brainstorming", args: "express: true. scope: [scope]. 
 
 For inline steps (CHANGELOG generation, self-review, code review, study existing patterns), the mode flag is already in the conversation context — no explicit propagation is needed.
 
+### Verify Acceptance Criteria — Pattern B Dispatch
+
+**Note:** INLINE-FALLBACK IS A ROLLOUT-ONLY FEATURE.
+<!-- feature-flow vNEXT+1 removes inline-fallback once two consecutive successful real-session uses are observed. -->
+
+**Applies in ALL modes** (YOLO, Express, Interactive — see the "Subagent dispatch patterns A and B" CRITICAL block above). `verify-acceptance-criteria` is the second Pattern B conversion (per #251 Wave 3 phase 4). Because the skill internally dispatches a single `task-verifier` subagent at Step 3 (which subagents cannot do per #251 Q1 — recursive dispatch silently fails), the orchestrator hoists the task-verifier dispatch to itself, then dispatches a single consolidator subagent that runs the rest of the skill (Steps 4-6) in isolation. The orchestrator never sees the plan content, the extracted criteria, or the detailed verification report — only the validated return contract.
+
+**Why skip the state-file bucket** (architectural deviation from `design-document` Pattern B): the four `phase_summaries` buckets (`brainstorm`, `design`, `plan`, `implementation`) are all claimed by phase-boundary writes. Verify-acceptance-criteria runs inside the Final Verification inline step, well after the implementation phase boundary; it is a verification step within the implementation phase, not a phase that owns a bucket. Reusing `phase_summaries.implementation.return_contract` would collide with the future Phase 6 (`subagent-driven-development`) Pattern B contract. The contract is consumed once by the orchestrator's validator and discarded — no cross-compaction reader needs it from the state file. Writing directly to a tmp JSON file avoids the collision and avoids a schema_version bump.
+
+**Sub-step 1 — Hoisted task-verifier dispatch (orchestrator-side):**
+
+The orchestrator dispatches the `feature-flow:task-verifier` subagent directly. The task-verifier reads the plan, extracts criteria, runs verifications, and writes the detailed Markdown report to a tmp path. Model per #251: `model: "haiku"` (focused mechanical verification — matches the existing inline-skill dispatch).
+
+```
+SLUG=<slug-from-session-context>
+REPORT_PATH="/tmp/ff-verify-ac-report-${SLUG}.md"
+PLAN_FILE="<absolute path to plan>"
+
+Task(
+  subagent_type: "feature-flow:task-verifier",
+  model: "haiku",
+  description: "verify-acceptance-criteria task-verifier",
+  prompt: "Read the implementation plan at ${PLAN_FILE}. Extract every \`**Acceptance Criteria:**\` section and its \`- [ ]\` items (or for XML plans, every \`<criterion>\` element). Verify each criterion against the codebase per agents/task-verifier.md Steps 1-3 (categorize, execute, diagnose). Write the detailed Markdown report (Results table + Summary + Verdict) to ${REPORT_PATH}. Then return ONLY a short JSON summary: {\"report_path\": \"${REPORT_PATH}\", \"verdict\": \"VERIFIED|INCOMPLETE|BLOCKED\", \"pass_count\": <int>, \"fail_count\": <int>, \"failed_criteria\": [{\"task_id\": \"Task N\", \"criterion\": \"<text>\", \"reason\": \"<one-line evidence>\"}, ...]}."
+)
+```
+
+**Sub-step 2 — Consolidator dispatch:**
+
+```
+CONTRACT_PATH="/tmp/ff-verify-ac-contract-${SLUG}.json"
+
+Task(
+  subagent_type: "general-purpose",
+  model: "sonnet",
+  description: "verify-acceptance-criteria Pattern B consolidator",
+  prompt: "Invoke Skill(skill: 'feature-flow:verify-acceptance-criteria', args: 'plan_file: ${PLAN_FILE}. verifier_report_path: ${REPORT_PATH}. write_contract_to: ${CONTRACT_PATH}'). The skill will skip Step 3 (already run by orchestrator), present the report from Step 4, optionally update plan checkboxes in Step 5, and write the return contract in Step 6. Return the contract path and a one-line summary."
+)
+```
+
+**Why `model: "sonnet"` for the consolidator:** Steps 4-5 do summary writing + checkbox edits across potentially many criteria; Sonnet handles the structured presentation without missing edge cases. Haiku is too brittle for the diagnose/present split; Opus is over-spec for what is mostly bookkeeping over an already-produced report.
+
+**Why `model: "haiku"` for the task-verifier:** Mechanical verification (file existence, grep, exit codes) plus pattern-matching diagnosis is exactly Haiku's wheelhouse. This matches the existing inline-skill choice for task-verifier dispatch.
+
+**Post-dispatch sequence (orchestrator-side):**
+
+1. **Verify the contract file was written:**
+   ```bash
+   [ -f "${CONTRACT_PATH}" ] && echo ok || echo missing
+   ```
+   If `missing` → trigger **inline-fallback** (case 3 below).
+2. **Validate the contract:**
+   ```bash
+   node hooks/scripts/validate-return-contract.js "${CONTRACT_PATH}"
+   ```
+   Exit 0 → proceed. Non-zero → trigger **inline-fallback** (case 4 below).
+3. **Read pass/fail counts** from the validated contract for downstream metadata-block population (`acceptance_criteria_count`, etc.). Proceed to next lifecycle step (Sync with base branch / Commit and PR).
+
+**Inline-fallback path** (rollout-only — four failure cases):
+
+| Case | Trigger | Announce | Next |
+|------|---------|----------|------|
+| 1 | Sub-step 1 task-verifier dispatch fails (timeout, tool error, refusal) | `verify-acceptance-criteria Pattern B: task-verifier dispatch failed (<reason>). Falling back to inline Skill().` | Run inline `Skill(skill: "feature-flow:verify-acceptance-criteria", args: "plan_file: <path>")` (no `verifier_report_path` — the skill runs its own Step 3) |
+| 2 | Consolidator `Task()` dispatch fails (timeout, tool error, refusal) | `verify-acceptance-criteria Pattern B: consolidator dispatch failed (<reason>). Falling back to inline Skill().` | Same inline invocation |
+| 3 | Consolidator completes but `write_contract_to` JSON file is missing or empty | `verify-acceptance-criteria Pattern B: consolidator did not write contract. Falling back to inline Skill().` | Same inline invocation |
+| 4 | `validate-return-contract.js` exits non-zero | `verify-acceptance-criteria Pattern B: contract validation failed (<error from validator>). Falling back to inline Skill().` | Same inline invocation |
+
+**The inline-fallback target is the bare `Skill()` form (the pre-#251 path). This is safe** — verify-acceptance-criteria's pre-#251 inline form ran in the orchestrator's own context, where the task-verifier `Task()` dispatch works. (Unlike `design-document`'s pre-#251 YOLO Task() wrapper which was latently broken; this skill never had a YOLO Task() wrapper to begin with — it was always invoked inline from the Final Verification step.)
+
+<!-- SUNSET NOTE: feature-flow vNEXT+1 removes this inline-fallback table and the four failure-case
+     handlers once two consecutive successful real-session uses of Pattern B are observed and the
+     measurement (per #253) confirms ≥5% orchestrator context reduction. The wrapper itself stays;
+     only the fallback safety net is sunset. -->
+
+**Call site:** the Pattern B wrapper is invoked from the Final Verification inline step (`skills/start/references/inline-steps.md` "Final Verification Step" section). The "Always run verify-acceptance-criteria" rule there now resolves to "Always run verify-acceptance-criteria via Pattern B dispatch" — see that section for integration with the quality-gate-skip logic.
+
 **Lifecycle Context Object:** As the lifecycle executes, maintain a context object that accumulates artifact paths as they become known. Include all known paths in the `args` of every subsequent `Skill` invocation, after the mode flag and scope:
 
 | Path key | When it becomes available |
@@ -952,7 +1027,7 @@ If the in-progress file does not exist (initial write failed), skip phase-bounda
 | Self-review | No skill — inline step (see below) | Code verified against coding standards before formal review |
 | Code review | No skill — inline step (see below) | All Critical/Important findings fixed, tests pass |
 | Generate CHANGELOG entry | No skill — inline step (see below) | Changelog fragment written to `.changelogs/<id>.md`; consolidated when `/merge-prs` is invoked |
-| Final verification | No skill — inline step (see below) | All criteria PASS + quality gates pass (or skipped if Phase 4 already passed) |
+| Final verification | No skill — inline step (see below). Calls `feature-flow:verify-acceptance-criteria` (invoked via Pattern B dispatch — orchestrator-side hoisted task-verifier `Task()` with `model: "haiku"` + consolidator `Task()` with `model: "sonnet"`; structured return contract written directly to a tmp JSON path — **no state-file bucket**, see "Verify Acceptance Criteria — Pattern B Dispatch" section above; inline-fallback path retained for rollout) | All criteria PASS + quality gates pass (or skipped if Phase 4 already passed); return contract validated via `hooks/scripts/validate-return-contract.js` |
 | Sync with base branch | No skill — inline step (see below) | Branch merged onto latest base branch; conflicts require manual resolution |
 | Commit and PR | `superpowers:finishing-a-development-branch` | PR URL; PR body includes `feature-flow-metadata` block (all modes). **Handoff file write:** Immediately after `gh pr create` returns the PR number, write `.feature-flow/handoffs/<pr-number>.yml` in the **base repo** (not the worktree — the file must survive worktree removal; resolve via `BASE_REPO=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)`, **not** `--show-toplevel`). Required fields: `schema_version: 1`, `pr_number: <N>`, `branch: <branch>`, `worktree_path: <abs-path>`, `base_branch: <base>`, `scope: <scope>`, `issue_number: <N-or-null>`, `created_at: <iso-utc>`, `slug: <slug>`, `feature_flow_version: <plugin-version>`. The write happens once, in a single step — no intermediate `pending-<slug>.yml` file, no rename. If the write fails, log a warning and continue (the worktree is still valid; the user can retry by running `cleanup-merged` manually later, though cleanup without a handoff requires manual worktree removal). **In-progress file removal (write-then-delete):** **After** the numbered handoff file is durably on disk (verify with `[ -f "${BASE_REPO}/.feature-flow/handoffs/<pr-number>.yml" ]`), delete the in-progress file: `rm -f "${BASE_REPO}/.feature-flow/handoffs/in-progress-${SLUG}.yml"` (where `SLUG` is the slug from session context — see the Worktree setup row's slug algorithm). `rm -f` exits cleanly when the file does not exist (initial in-progress write failed); do not error. **Order matters:** the two files briefly co-exist between the handoff write and the in-progress delete, which is harmless (different filenames, no clobber; cleanup-merged distinguishes by filename pattern; resume scans match only `in-progress-*.yml`; PR-state checks match only numbered `*.yml`). If the order were reversed and the numbered handoff write failed, both files would be gone — leaving the worktree fully orphaned. The two file forms are mutually exclusive at steady state — only one exists per slug after the swap completes. |
 | Wait for CI and address reviews | No skill — inline step (see below) | CI green, review comments addressed |

--- a/skills/start/references/inline-steps.md
+++ b/skills/start/references/inline-steps.md
@@ -486,7 +486,7 @@ This step runs after CHANGELOG generation and before commit and PR. It verifies 
    - If marker matches HEAD (`$CURRENT_HEAD` = `$SAVED_HEAD`) **and** `git status --porcelain` is empty: Skip `verification-before-completion`. Announce: "Quality gates already passed (verified at HEAD, working tree clean) — skipping redundant checks."
    - If marker does not match HEAD **or** working tree is dirty: Run `verification-before-completion` normally.
 
-2. **Always run `verify-acceptance-criteria`:** This checks plan-specific criteria and must always run regardless of quality gate skip.
+2. **Always run `verify-acceptance-criteria` via Pattern B dispatch:** This checks plan-specific criteria and must always run regardless of quality gate skip. As of #251 Wave 3 phase 4, the call is dispatched as Pattern B (orchestrator-side hoisted task-verifier dispatch with `model: "haiku"` + consolidator `Task()` with `model: "sonnet"`). The contract is written to `/tmp/ff-verify-ac-contract-<slug>.json` (no state-file write — see "Verify Acceptance Criteria — Pattern B Dispatch" in `skills/start/SKILL.md` for rationale and the inline-fallback path). The Pattern B wrapper applies in all modes (YOLO, Express, Interactive). The contract's `pass_count`, `fail_count`, and `failed_criteria` populate the metadata-block fields below in step 3.
 
 3. **Write verification marker:** After all checks pass (both acceptance criteria and any quality gates that ran), write the HEAD commit hash to the git directory for the stop hook to read:
    ```bash

--- a/skills/verify-acceptance-criteria/SKILL.md
+++ b/skills/verify-acceptance-criteria/SKILL.md
@@ -20,6 +20,17 @@ Mechanically checks all acceptance criteria from an implementation plan against 
 - Before claiming work is complete
 - Before committing or creating a PR
 
+## Optional Args (used when invoked from orchestrator dispatch)
+
+When invoked as a Pattern B consolidator subagent (per #251 Wave 3 phase 4), the orchestrator passes these arguments so the skill can skip the hoisted task-verifier dispatch and write its structured return contract back to a tmp JSON file:
+
+- `verifier_report_path: <absolute-path-to-report-md>` — when set, the skill skips Step 3's `task-verifier` dispatch (the orchestrator has already executed it) and reads the pre-written verification report from this Markdown file. The report follows the format defined in `agents/task-verifier.md` Step 4.
+- `write_contract_to: <absolute-path-to-json>` — when set, writes the structured return contract directly to this JSON file path after Step 4 (Present Results) completes (see Step 6 below). **Unlike `design-document`, this is a plain JSON file path, not a state-file YAML path.** verify-acceptance-criteria does not own a `phase_summaries` bucket — see "Why no state-file write" below.
+
+Both args are optional. If `verifier_report_path` is absent, Step 3 dispatches the task-verifier as before. If `write_contract_to` is absent, Step 6 is skipped — the skill behaves identically to its inline-invocation form.
+
+**Why no state-file write:** the four `phase_summaries` buckets (`brainstorm`, `design`, `plan`, `implementation`) are all claimed by phase-boundary writes. Verify-acceptance-criteria is a verification step within the implementation phase, not a phase that owns a bucket; reusing `implementation.return_contract` would collide with the future Phase 6 (`subagent-driven-development`) Pattern B contract. The contract is consumed once by the orchestrator's validator and discarded — no cross-compaction reader needs it from the state file.
+
 ## Format Detection
 
 Before extracting criteria, determine which format the plan file uses.
@@ -118,6 +129,8 @@ If a specific task was requested, only extract criteria for that task.
 
 ### Step 3: Delegate to Task Verifier
 
+**Pattern B consolidator-mode early exit:** If `verifier_report_path` is set in ARGUMENTS, the orchestrator has already dispatched the task-verifier and written its detailed Markdown report to that path. Read the file, treat its content as the verification report produced by Step 3, and skip the `Task()` dispatch below. Jump directly to Step 4 (Present Results) using the loaded report. This branch exists for the Pattern B subagent dispatch wired in `skills/start/SKILL.md` — see "Verify Acceptance Criteria — Pattern B Dispatch" in that file.
+
 Use the Task tool with `subagent_type: "feature-flow:task-verifier"` and `model: "haiku"` (see `../../references/tool-api.md` — Task Tool for correct parameter syntax) to launch the task-verifier agent with:
 
 ```
@@ -195,3 +208,56 @@ the plan is in XML mode and all criteria for a task pass, offer to update `statu
 ```
 
 Only do this if the user agrees.
+
+### Step 6: Write Return Contract (conditional)
+
+**Only executes if `write_contract_to` is set in the skill's ARGUMENTS.** If the arg is absent, skip this step entirely — the skill behaves identically to its pre-#251 inline form.
+
+Construct the return contract object per the locked spec from #251 (exemplar 2 in the issue body, locked before any implementation):
+
+- `schema_version`: `1` (integer — contract schema version)
+- `phase`: hardcoded to `"verify-acceptance-criteria"` per #251's locked contract spec — this is the lifecycle step name the validator uses to look up the schema in its registry.
+- `status`: derived from the verifier verdict —
+  - `"success"` → all criteria PASS or CANNOT_VERIFY (verdict VERIFIED)
+  - `"partial"` → at least one criterion FAIL (verdict INCOMPLETE)
+  - `"failed"` → verifier could not run (verdict BLOCKED — broken build, missing deps)
+- `report_path`: absolute path of the detailed Markdown verification report (the `verifier_report_path` arg if set; otherwise the path to the inline-fallback report)
+- `pass_count`: integer count of PASS rows in the report
+- `fail_count`: integer count of FAIL rows in the report
+- `failed_criteria`: array of objects, one per FAIL row. Each object has string fields `task_id`, `criterion`, `reason` (extracted from the report's Results table). Empty array `[]` when status is `success`.
+
+Write the contract directly to the JSON path using this helper (env-var passing is apostrophe-safe, mirrors the pattern in `skills/design-document/SKILL.md` Step 8):
+
+```bash
+F="<write_contract_to value>"
+STATUS="<success|partial|failed>"
+REPORT="<absolute path to the detailed report>"
+PASS=<integer>
+FAIL=<integer>
+FAILED='<json-array-string, e.g. [] or [{"task_id":"Task 3","criterion":"...","reason":"..."}]>'
+
+F="$F" STATUS="$STATUS" REPORT="$REPORT" PASS="$PASS" FAIL="$FAIL" FAILED="$FAILED" python3 -c '
+import os, json
+contract = {
+    "schema_version": 1,
+    # The contracts `phase` field is the lifecycle STEP NAME per #251 spec.
+    # The validator uses this to look up the schema in its registry.
+    "phase": "verify-acceptance-criteria",
+    "status": os.environ["STATUS"],
+    "report_path": os.environ["REPORT"],
+    "pass_count": int(os.environ["PASS"]),
+    "fail_count": int(os.environ["FAIL"]),
+    "failed_criteria": json.loads(os.environ["FAILED"]),
+}
+json.dump(contract, open(os.environ["F"], "w"))
+print(f"[verify-acceptance-criteria] return_contract written to {os.environ[\"F\"]}")
+'
+```
+
+**No `[ -f "$F" ]` guard** — unlike `design-document` (which writes into an existing state-file YAML), this skill writes a fresh JSON file. The orchestrator passes a tmp path that the helper creates.
+
+After writing, return the contract path and a one-line summary as the skill's result text:
+
+`"Return contract written to <write_contract_to>. Verification: status=<status>, pass=<N>, fail=<N>."`
+
+The orchestrator (Pattern B wrapper in `skills/start/SKILL.md`) reads this path from the result string and runs `hooks/scripts/validate-return-contract.js` against it before proceeding.


### PR DESCRIPTION
Wave 3 phase 4 of issue #251 (subagent-driven phase architecture).

## What landed (per #251's per-phase implementation criteria)

- [x] Phase's return contract specified inline in #251 (exemplar 2 in the issue body — locked before any implementation; matches the schema validator entry)
- [x] Dispatch wrapper includes explicit `model:` parameter (Haiku for the hoisted task-verifier dispatch, Sonnet for the consolidator)
- [x] Schema validation applied to the return value at the orchestrator boundary (`hooks/scripts/validate-return-contract.js` extended with `verify-acceptance-criteria` SCHEMAS entry + per-item check for the new array-of-objects `failed_criteria` field; 7 new unit tests; e2e round-trip passes)
- [x] Inline-fallback present in this PR with explicit sunset (vNEXT+1 after two successful real-session uses; 4 failure cases routing to bare `Skill()`)
- [ ] **PENDING (post-merge):** Real-session #253 measurement showing orchestrator context reduction; if <5%, abort per #251's per-phase decision rule
- [ ] **FUTURE PR:** Followup PR removes inline-fallback after two successful real-session uses

## Architectural deviation — bucket-skip (lead with this; reviewer-fixation point)

**Pattern B variant: the contract is written directly to a tmp JSON file (`/tmp/ff-verify-ac-contract-${SLUG}.json`) — no `phase_summaries` bucket write.** This deviates from PR #263 (design-document) which writes to `phase_summaries.design.return_contract` in the in-progress YAML.

Three reasons:

1. **Bucket exhaustion.** The four `phase_summaries` buckets (`brainstorm`, `design`, `plan`, `implementation`) are all claimed by phase-boundary writes. There is no semantically natural slot for verify-acceptance-criteria — it is a verification step _within_ the implementation phase, not a phase that owns a bucket.
2. **Phase 6 collision.** Reusing `phase_summaries.implementation.return_contract` would collide with the future Phase 6 (`subagent-driven-development`) Pattern B contract. Verify-acceptance-criteria runs in Final Verification (after subagent-driven-development), so its write would clobber Phase 6's contract.
3. **No cross-compaction reader.** The contract is consumed once by the orchestrator's validator and discarded. Nothing reads it after that single turn — the state-file substrate's main value (cross-compaction persistence) doesn't apply.

Skipping the bucket avoids the collision **and** avoids a `schema_version` bump (which would touch `cleanup-merged` guards and the in-progress initial-write helper). Documented in `skills/start/SKILL.md` "Why skip the state-file bucket" rationale paragraph.

## Latent bug fix (same shape as PR #263)

The pre-#251 `feature-flow:verify-acceptance-criteria` ran inline from the Final Verification step and dispatched `feature-flow:task-verifier` via `Task()` from inside the skill. If the lifecycle ever wrapped Final Verification in a subagent (per the convergence trajectory of #251), the inner `Task()` would have silently failed (subagents cannot dispatch sub-subagents per #251 Q1). Pattern B hoists the task-verifier dispatch to the orchestrator where it works.

(Unlike PR #263's case — where a YOLO Task() wrapper for design-document was actively broken in production — verify-acceptance-criteria was always invoked inline, so the bug was latent rather than active. Either way, Pattern B is the correct shape.)

## Files

- `hooks/scripts/validate-return-contract.js` — SCHEMAS entry + array-of-objects check for `failed_criteria`
- `hooks/scripts/validate-return-contract.test.js` — 7 new unit tests (22 passing total)
- `hooks/scripts/validate-return-contract.e2e.sh` — new Pattern B section: consolidator → tmp-json → validator (no state-file)
- `hooks/scripts/fixtures/valid-verify-acceptance-criteria.json` — new fixture
- `skills/verify-acceptance-criteria/SKILL.md` — Optional Args section, Step 3 `verifier_report_path` early-exit, Step 6 contract write helper
- `skills/start/SKILL.md` — Pattern B wrapper section, Pattern A/B summary update, Skill Mapping "Final verification" row updated
- `skills/start/references/inline-steps.md` — Final Verification step references the new Pattern B wrapper
- `docs/plans/2026-05-03-verify-acceptance-criteria-pattern-b.md` — implementation plan (verified: 42/49 criteria pass; 4 expected fails were the changelog-not-yet-written rows; 3 minor mismatches caught by self-verification and fixed pre-commit)
- `.changelogs/2026-05-03-verify-acceptance-criteria-pattern-b.md` — changelog fragment

## Updated phase audit (Wave 3 phase 4)

| Phase | Pattern | Status |
|---|---|---|
| `verify-plan-criteria` | A | Shipped #262; sunset pending (1 of 2 real-session uses captured) |
| `merge-prs` | A | Skipped — no orchestrator-side benefit ([comment](https://github.com/uta2000/feature-flow/issues/251#issuecomment-4365149973)) |
| `design-document` | B | Shipped #263; sunset pending (1 of 2 real-session uses) |
| `verify-acceptance-criteria` | B | This PR |
| `code-review` | B | Pending (Wave 3 phase 5) |
| `implementation` | B | Pending (Wave 3 phase 6) |
| `design-verification` | Inline | Already orchestrator-thin |

## Test plan

- [x] `node hooks/scripts/validate-return-contract.test.js` — 22/22 passing
- [x] `bash hooks/scripts/validate-return-contract.e2e.sh` — all three pipelines (Pattern A, design-document Pattern B, verify-acceptance-criteria Pattern B) emit PASS lines, exit 0
- [x] Self-verification via task-verifier: 42/49 plan criteria PASS pre-commit (the 4 expected Task 7 / changelog fails resolved by writing the changelog; 3 phrasing mismatches resolved before commit)
- [ ] Post-merge: real-session use exercises the new Pattern B dispatch end-to-end
- [ ] Post-merge: #253 measurement on a real session for the per-phase decision rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)