### PR TITLE
feat(start): convert code-review to Pattern B subagent dispatch (#251)

### DIFF
--- a/.changelogs/2026-05-03-code-review-pattern-b.md
+++ b/.changelogs/2026-05-03-code-review-pattern-b.md
@@ -1,0 +1,50 @@
+### Added — code-review Pattern B subagent dispatch (#251 Wave 3 phase 5)
+
+The Code Review lifecycle step now runs as Pattern B (orchestrator-side parallel reviewer
+fanout + consolidator subagent). The orchestrator continues to dispatch Phase 0 (deterministic
+pre-filter), Phase 1a (pr-review-toolkit), Phase 1b (report-only agents in parallel), and
+Phase 1c (senior panel — Major-feature scope only) — those dispatches MUST stay orchestrator-side
+because subagents cannot recursively dispatch (per #251 Q1, fixed in PRs #262/#263/#264).
+A new consolidator subagent (`general-purpose`, `model: "sonnet"`) ingests the reviewer outputs
+and runs Phases 2-5 in isolation: conflict detection, fix application, targeted re-verification,
+report assembly, and contract write. The return contract is validated by
+`hooks/scripts/validate-return-contract.js` before the lifecycle proceeds.
+
+**Architectural deviation — bucket-skip variant** (mirrors PR #264, `verify-acceptance-criteria`):
+the contract is written directly to `/tmp/ff-code-review-contract-${SLUG}.json` rather than
+into a `phase_summaries` bucket on the in-progress state file. The four buckets (`brainstorm`,
+`design`, `plan`, `implementation`) are all claimed by phase-boundary writes; the natural
+`implementation` slot is reserved for future Phase 6 (`subagent-driven-development`) Pattern B.
+Code-review is a verification step within the implementation phase, not a phase that owns a
+bucket — so skipping the state-file mediation avoids the collision with no functional cost.
+No `schema_version` bump.
+
+**Phase 4 changes for Pattern B:**
+
+- The `superpowers:code-reviewer rule 6 → run verify-acceptance-criteria` row and the
+  `No Critical/Important findings → run verify-acceptance-criteria as baseline sanity check`
+  row are both deleted from the targeted-checks table. The Final Verification inline step
+  runs verify-acceptance-criteria immediately after the code-review step anyway — both
+  invocations were redundant, and inside the consolidator they would have failed
+  (verify-acceptance-criteria internally dispatches `task-verifier`, which subagents cannot
+  do per #251 Q1).
+- Agent re-dispatch is unavailable inside the consolidator (same Q1 constraint). Each Phase 4
+  row that would have triggered an agent re-dispatch instead writes a `deferred[]` entry to
+  the return contract with `reason: "agent re-dispatch unavailable in Pattern B consolidator"`.
+  A verdict-honesty constraint enforces this: the consolidator MUST NOT return
+  `verdict: "approve"` while `deferred[]` is non-empty due to agent re-dispatch unavailability.
+  The inline-fallback path retains the actual re-dispatch behavior (orchestrator-level
+  dispatch works there).
+
+**Inline-fallback** (rollout-only) is retained for four failure cases (cascading reviewer
+dispatch failure, consolidator dispatch failure, missing contract file, validator non-zero
+exit). Sunset target: `feature-flow vNEXT+1` after two consecutive successful real-session uses.
+
+**Per-phase decision rule (#251):** the ≥5% orchestrator-context-reduction measurement (per
+#253 instrumentation) is deferred to post-merge real-session use, mirroring the explicit
+deferral in PRs #263 and #264.
+
+**Phase 1c session correlation preserved:** the `[session:$LIFECYCLE_SESSION]` token is passed
+to the consolidator in its dispatch prompt and stamped on every Phase 5 report entry — same
+requirement as inline mode, preserved across the Pattern B handoff so grep-correlation across
+pipeline phases, the Phase 5 report, and the PR body still works.

--- a/docs/plans/2026-05-03-code-review-pattern-b.md
+++ b/docs/plans/2026-05-03-code-review-pattern-b.md
@@ -1,0 +1,183 @@
+# code-review Pattern B Conversion — Implementation Plan
+
+**Date:** 2026-05-03
+**Issue:** #251 (Wave 3 phase 5)
+**Status:** Ready for implementation
+**Reference PR:** #264 (verify-acceptance-criteria Pattern B precedent — bucket-skip variant)
+**Reference PR:** #263 (design-document Pattern B precedent — validator + e2e shape)
+**Locked contract:** https://github.com/uta2000/feature-flow/issues/251#issuecomment-4366218476
+
+## Summary
+
+Convert the **Code Review** lifecycle step (currently driven inline from `skills/start/SKILL.md` via `skills/start/references/code-review-pipeline.md`) to Pattern B subagent dispatch per #251. The orchestrator continues to dispatch the parallel reviewer fanout (Phase 1a pr-review-toolkit + Phase 1b report-only agents + Phase 1c senior panel) — those dispatches MUST stay orchestrator-side because subagents cannot recursively dispatch (#251 Q1). A new consolidator subagent ingests the reviewer outputs and runs Phases 2-5 in isolation: conflict detection, fix application, targeted re-verification, report assembly, and contract write.
+
+**Bucket-skip variant.** Mirror PR #264 (`verify-acceptance-criteria`). The four `phase_summaries` buckets (`brainstorm`, `design`, `plan`, `implementation`) are all claimed; the natural `implementation` slot is reserved for Wave 3 phase 6's `subagent-driven-development` Pattern B contract. Code-review is a verification step within the implementation phase, not a phase that owns a bucket. The consolidator writes the contract directly to `/tmp/ff-code-review-contract-${SLUG}.json` and the orchestrator validates from that path.
+
+## Locked return contract
+
+Per #251 Wave 3 phase 5 contract comment (locked before any implementation):
+
+```json
+{
+  "schema_version": 1,
+  "phase": "code-review",
+  "status": "success | partial | failed",
+  "verdict": "approve | needs_changes | blocked",
+  "report_path": "string (absolute path to the persisted code-review report on disk)",
+  "critical_count": "integer",
+  "important_count": "integer",
+  "suggestion_count": "integer",
+  "fixed_in_pipeline": [{"severity": "critical|important|suggestion", "summary": "string"}],
+  "deferred":          [{"severity": "critical|important|suggestion", "summary": "string", "reason": "string"}]
+}
+```
+
+**Validator extension.** Two new array-of-objects shapes (`fixed_in_pipeline`, `deferred`) plus a closed-enum check on `verdict`. Mirrors the `failed_criteria` array-of-objects validation shipped in PR #264; same hand-rolled style — no `ajv` dependency.
+
+## Architectural decisions (locked from advisor consultation)
+
+1. **Consolidator scope = Phases 2-5 entirely.** Phase 0 (deterministic pre-filter), Phase 1a (pr-review-toolkit dispatch), Phase 1b (report-only parallel dispatches), and Phase 1c (senior panel dispatch) all stay orchestrator-side. The constraint that decides what goes where: *can it dispatch Agent/Task?* If yes → orchestrator. If no → consolidator.
+2. **Phase 4 `verify-acceptance-criteria` re-verify row is dropped from Pattern B.** Post-#264, the verify-acceptance-criteria skill internally `Task()`s the task-verifier — which silently fails inside a wrapping subagent (Q1). The Final Verification inline step runs verify-acceptance-criteria immediately after the code-review step anyway, so the Phase 4 row is duplicate work.
+3. **Phase 4 agent re-dispatch becomes explicit `deferred[]` entries.** Each re-dispatch row that triggers in the consolidator yields a `deferred[]` entry with `reason: "agent re-dispatch unavailable in Pattern B consolidator"`. This keeps the verdict honest — the consolidator MUST NOT return `verdict: "approve"` while critical findings remain unverified by their original reporter.
+4. **Phase 1c `[session:$LIFECYCLE_SESSION]` correlation token flows through.** The orchestrator passes the session slug into the consolidator dispatch prompt; the consolidator stamps it on every Phase 5 report entry per `senior-panel.md` requirements.
+5. **Pattern B wrapper applies at every scope where the existing pipeline runs.** Quick fix is already skipped (no change). Small enhancement, Feature, and Major feature all use Pattern B. Do not narrow.
+
+## Tasks
+
+### Task 1 — Extend validator schema for `code-review`
+
+Add a `SCHEMAS['code-review']` entry to `hooks/scripts/validate-return-contract.js`. Add closed-enum validation for `verdict`. Add per-item validation for `fixed_in_pipeline[]` (each item: `{severity: string ∈ {critical, important, suggestion}, summary: string}`) and `deferred[]` (each item: `{severity: string ∈ {critical, important, suggestion}, summary: string, reason: string}`).
+
+**Acceptance Criteria:**
+- [ ] `hooks/scripts/validate-return-contract.js` `SCHEMAS` object contains a `'code-review'` key
+- [ ] The schema declares 10 fields: `schema_version`, `phase`, `status`, `verdict`, `report_path`, `critical_count`, `important_count`, `suggestion_count`, `fixed_in_pipeline`, `deferred`
+- [ ] Validator code includes a closed-enum check rejecting any `verdict` value other than `approve`, `needs_changes`, `blocked`
+- [ ] Validator code includes a per-item check for `fixed_in_pipeline[]`: each item must be an object with string fields `severity`, `summary`; `severity` must be one of `critical | important | suggestion`
+- [ ] Validator code includes a per-item check for `deferred[]`: each item must be an object with string fields `severity`, `summary`, `reason`; `severity` must be one of `critical | important | suggestion`
+- [ ] Running `node hooks/scripts/validate-return-contract.js hooks/scripts/fixtures/valid-code-review.json` exits 0 (after Task 2 ships the fixture)
+
+### Task 2 — Add fixture and unit tests for `code-review` schema
+
+Create a valid fixture and extend the validator unit tests with code-review coverage. Mirror PR #264's test structure (one VALID constant + ~7 test functions covering valid case, missing field, bad item shapes, valid enum-rejection cases).
+
+**Acceptance Criteria:**
+- [ ] File exists at `hooks/scripts/fixtures/valid-code-review.json`
+- [ ] Fixture's `phase` field is the string `"code-review"`
+- [ ] Fixture has `verdict: "approve"`, `critical_count: 0`, `important_count: 0`, `suggestion_count: 0`, `fixed_in_pipeline: []`, `deferred: []` (clean success case)
+- [ ] `hooks/scripts/validate-return-contract.test.js` defines a `VALID_CR` constant with all 10 fields
+- [ ] Test "code-review: valid contract exits 0" passes
+- [ ] Test "code-review: missing required field exits 1" passes (delete `verdict`)
+- [ ] Test "code-review: invalid verdict value exits 1" passes (set `verdict: "approved"` — wrong enum)
+- [ ] Test "code-review: fixed_in_pipeline with non-object item exits 1" passes (item is a string)
+- [ ] Test "code-review: fixed_in_pipeline with bad severity exits 1" passes (severity is `"high"`)
+- [ ] Test "code-review: deferred missing reason exits 1" passes (item lacks `reason` field)
+- [ ] Test "code-review: needs_changes verdict with non-empty fixed_in_pipeline + deferred is valid" passes
+- [ ] `node hooks/scripts/validate-return-contract.test.js` exits 0 with all tests passing
+
+### Task 3 — Restructure `code-review-pipeline.md` for Pattern B consolidator mode
+
+Modify `skills/start/references/code-review-pipeline.md` to clearly delineate orchestrator-owned phases (0, 1a, 1b, 1c) from consolidator-owned phases (2, 3, 4, 5 + contract write). The doc's Process section is reorganised into two halves with an explicit handoff. The consolidator section embeds:
+- A new "Pattern B handoff" subsection at the top of Phase 2 explaining what the consolidator receives (raw Phase 1a/1b/1c outputs + `lifecycle_session` token + `write_contract_to` path)
+- The Phase 4 row for `superpowers:code-reviewer rule 6 → run verify-acceptance-criteria` is deleted from the targeted-checks table with a note that Final Verification covers it
+- A new Phase 4 paragraph explaining that agent re-dispatch is unavailable inside the consolidator: each re-dispatch row that triggers writes a `deferred[]` entry to the contract instead of dispatching
+- A new "Phase 5: Report and Contract Write" subsection that adds the contract construction + write step (mirrors PR #264's verify-acceptance-criteria Step 6 helper) and requires every report entry to carry the `[session:$LIFECYCLE_SESSION]` token
+- The Phase 1c `[session:$LIFECYCLE_SESSION]` correlation requirement is restated at the consolidator boundary so it's preserved through the handoff
+
+**Acceptance Criteria:**
+- [ ] `skills/start/references/code-review-pipeline.md` contains a new top-level subsection heading `## Pattern B handoff (orchestrator → consolidator)`
+- [ ] The handoff subsection enumerates exactly four inputs the consolidator receives: Phase 1a summary, Phase 1b structured findings, Phase 1c findings (when present), and `lifecycle_session` slug
+- [ ] The handoff subsection states explicitly that the consolidator owns Phases 2, 3, 4, 5
+- [ ] The Phase 4 targeted-checks table no longer contains a row for `superpowers:code-reviewer rule 6 → verify-acceptance-criteria`
+- [ ] A note exists immediately after the Phase 4 targeted-checks table explaining the deletion ("Final Verification covers this — see `skills/start/references/inline-steps.md` Final Verification Step")
+- [ ] Phase 4 contains a new paragraph stating that agent re-dispatch is unavailable in the consolidator and that each row that would have triggered re-dispatch instead writes a `deferred[]` entry with `reason: "agent re-dispatch unavailable in Pattern B consolidator"` to the return contract
+- [ ] Phase 4 paragraph explicitly forbids returning `verdict: "approve"` when `deferred[]` is non-empty due to agent re-dispatch unavailability
+- [ ] Phase 5 contains a new "Contract Write" subsection (or equivalent named heading) directing the consolidator to write the contract to the orchestrator-provided `write_contract_to` JSON path with all 10 locked fields including `phase: "code-review"` (hardcoded — not derived from any arg)
+- [ ] The Contract Write subsection uses env-var passing and `python3 -c` for the JSON write (mirrors PR #264 Step 6 helper)
+- [ ] Phase 5 explicitly requires every report entry produced by the consolidator to carry the `[session:$LIFECYCLE_SESSION]` correlation token (preserves the senior-panel.md requirement)
+- [ ] The doc's existing "Phase 5: Report" output template is extended with the verdict line emitted from the consolidator
+
+### Task 4 — Add "Code Review — Pattern B Dispatch" wrapper to `skills/start/SKILL.md`
+
+Add a new subsection in `skills/start/SKILL.md` mirroring the existing "Verify Acceptance Criteria — Pattern B Dispatch" section (line ~867). The wrapper documents:
+- Sub-step 1 (already-existing orchestrator behavior — Phase 0 pre-filter)
+- Sub-step 2 (already-existing orchestrator dispatches — Phase 1a, 1b, 1c)
+- Sub-step 3 (NEW — single consolidator `Task()` dispatch with `model: "sonnet"` and `subagent_type: "general-purpose"`)
+- Inline-fallback table (4 cases mirroring PR #264)
+- Bucket-skip rationale paragraph
+- Sunset note (vNEXT+1)
+
+Update the Pattern A/B status summary line at SKILL.md:683 to list `code-review` alongside `verify-acceptance-criteria`.
+
+**Acceptance Criteria:**
+- [ ] `skills/start/SKILL.md` contains a new section heading `### Code Review — Pattern B Dispatch`
+- [ ] The new section is positioned after the existing "Verify Acceptance Criteria — Pattern B Dispatch" section
+- [ ] Section opens with the `INLINE-FALLBACK IS A ROLLOUT-ONLY FEATURE` note plus an HTML-comment SUNSET line referencing `feature-flow vNEXT+1`
+- [ ] Section explicitly says it applies in all modes (YOLO, Express, Interactive) at every scope where the existing pipeline runs (Small enhancement, Feature, Major feature — Quick fix already skipped)
+- [ ] Section includes a "Why skip the state-file bucket" rationale paragraph (4 fixed buckets all claimed; future Phase 6 collision; no cross-compaction reader needed)
+- [ ] Section documents Sub-step 1 (Phase 0 pre-filter — orchestrator-side, unchanged)
+- [ ] Section documents Sub-step 2 (Phase 1a/1b/1c parallel reviewer dispatches — orchestrator-side, unchanged; subagents cannot recursively dispatch per Q1)
+- [ ] Section documents Sub-step 3: a single consolidator `Task()` dispatch with explicit `model: "sonnet"`, `subagent_type: "general-purpose"`, and a description like `"code-review Pattern B consolidator"`
+- [ ] Sub-step 3's prompt passes the consolidator: the Phase 1a summary, the Phase 1b findings, the Phase 1c findings (or empty), the `lifecycle_session` slug, the `write_contract_to` JSON path, and the plan-file path
+- [ ] Sub-step 3's prompt instructs the consolidator to read `skills/start/references/code-review-pipeline.md` Phases 2-5 and execute them in isolation, write the report, and write the contract to `${CONTRACT_PATH}`
+- [ ] Section includes a 4-row inline-fallback table covering: Phase 1a/1b/1c dispatch failure (existing handlers retained), consolidator dispatch failure, missing contract file, validator non-zero exit
+- [ ] Inline-fallback target for consolidator failure cases is the existing inline pipeline path (read `code-review-pipeline.md` and run Phases 2-5 inline)
+- [ ] Post-dispatch sequence documents: `[ -f "${CONTRACT_PATH}" ]` check, `node hooks/scripts/validate-return-contract.js "${CONTRACT_PATH}"`, then read of `verdict` from the contract to feed the lifecycle decision (verdict = `blocked` halts the lifecycle; `needs_changes` continues but flags the PR; `approve` continues normally)
+- [ ] The line at `skills/start/SKILL.md:683` (Pattern A/B status summary) lists `code-review` as converted to Pattern B and removes it from the "Future conversions" list (only `implementation` remains)
+
+### Task 5 — Update Skill-mapping table row for Code review in `skills/start/SKILL.md`
+
+The Skill-mapping table at SKILL.md line ~1028 has a `Code review` row currently saying `No skill — inline step (see below)`. Update the row's "Expected Output" or description column to reference the new "Code Review — Pattern B Dispatch" section, mirroring the verify-acceptance-criteria row update done in PR #264.
+
+**Acceptance Criteria:**
+- [ ] The Skill-mapping table row for `Code review` references the new "Code Review — Pattern B Dispatch" section in `skills/start/SKILL.md`
+- [ ] The row notes that the contract is written to `/tmp/ff-code-review-contract-<slug>.json` (no state-file bucket)
+- [ ] The row notes that Pattern B applies in all modes (YOLO, Express, Interactive)
+- [ ] The "All Critical/Important findings fixed, tests pass" semantics in the Expected Output are preserved (or expanded to add: `verdict ∈ {approve, needs_changes}` returned via validated contract; `blocked` halts the lifecycle)
+
+### Task 6 — Add e2e round-trip test for Pattern B `code-review` pipeline
+
+Extend `hooks/scripts/validate-return-contract.e2e.sh` with a fourth pipeline section (after the existing verify-acceptance-criteria one): build a contract object as the consolidator subagent would, write it directly to `/tmp/ff-code-review-contract-${SLUG}.json` (no state-file mediation), and run the validator against it. Update the trap cleanup to remove the new tmp file.
+
+**Acceptance Criteria:**
+- [ ] `hooks/scripts/validate-return-contract.e2e.sh` contains a new section header `# Pattern B round-trip — code-review`
+- [ ] Section writes a JSON contract directly to `/tmp/ff-code-review-contract-${SLUG}.json` (no state-file write — verify in section comment that this is intentional, mirroring the verify-acceptance-criteria section)
+- [ ] Section's contract has `phase: "code-review"`, `verdict: "approve"`, and all 10 locked fields populated
+- [ ] Section runs `node "${SCRIPT_DIR}/validate-return-contract.js" "$CR_CONTRACT_JSON"`
+- [ ] Section emits an `e2e PASS (code-review Pattern B)` line on success
+- [ ] Trap cleanup is updated to also remove the new tmp contract file (`rm -f` covers all four contract paths)
+- [ ] `bash hooks/scripts/validate-return-contract.e2e.sh` exits 0 end-to-end (all four pipelines pass)
+
+### Task 7 — Generate CHANGELOG fragment
+
+Write a single-file changelog fragment under `.changelogs/` describing the Pattern B conversion, the bucket-skip architectural deviation, the consolidator scope (Phases 2-5), the dropped Phase 4 row, the agent re-dispatch → deferred[] mapping, and the inline-fallback sunset target.
+
+**Acceptance Criteria:**
+- [ ] File exists at `.changelogs/2026-05-03-code-review-pattern-b.md`
+- [ ] Fragment includes the conversion summary (code-review → Pattern B per #251 Wave 3 phase 5)
+- [ ] Fragment notes the bucket-skip architectural deviation explicitly (mirrors PR #264)
+- [ ] Fragment notes that the consolidator owns Phases 2-5; orchestrator retains Phases 0, 1a, 1b, 1c
+- [ ] Fragment notes the Phase 4 `verify-acceptance-criteria` row deletion and the Final Verification redundancy rationale
+- [ ] Fragment notes the Phase 4 agent-re-dispatch → `deferred[]` mapping
+- [ ] Fragment notes the inline-fallback sunset target (vNEXT+1)
+
+## Implementation order
+
+Tasks must run sequentially (sequential dependencies, not parallel):
+
+1. Task 1 (validator schema) — foundation
+2. Task 2 (fixture + unit tests) — depends on Task 1
+3. Task 3 (code-review-pipeline.md restructure) — independent of validator work
+4. Task 4 (start/SKILL.md Pattern B wrapper) — depends on Tasks 1 + 3 contracts being settled
+5. Task 5 (Skill-mapping table row) — depends on Task 4
+6. Task 6 (e2e round-trip test) — depends on Task 1
+7. Task 7 (CHANGELOG fragment) — last
+
+Tasks 1+2 can run before 3, then 3 can run independently of 1/2, then 4+5+6+7 in order. In practice, run 1→2→3→4→5→6→7 sequentially to keep the diff coherent.
+
+## Out of scope
+
+- **Modifying `pr-review-toolkit:review-pr` or any of the report-only agents** — Pattern B does not touch the agents themselves, only the orchestration of their outputs.
+- **State-file integration for the code-review contract** — explicitly rejected per the bucket-skip rationale.
+- **Phase 4 agent re-dispatch as an orchestrator-side fallback** — explicitly punted to `deferred[]` entries; revisit only if post-merge measurement shows this is causing real verdict drift.
+- **Measurement (#253)** — deferred to post-merge real-session use, mirroring PRs #263 and #264.
+- **Sunsetting prior phases' inline-fallbacks** — those are tracked in #251 and shipped in separate PRs once their two-real-session-use clocks complete.

--- a/docs/plans/2026-05-03-code-review-pattern-b.md
+++ b/docs/plans/2026-05-03-code-review-pattern-b.md
@@ -26,9 +26,9 @@ Per #251 Wave 3 phase 5 contract comment (locked before any implementation):
   "report_path": "string (absolute path to the persisted code-review report on disk)",
   "critical_count": "integer",
   "important_count": "integer",
-  "suggestion_count": "integer",
-  "fixed_in_pipeline": [{"severity": "critical|important|suggestion", "summary": "string"}],
-  "deferred":          [{"severity": "critical|important|suggestion", "summary": "string", "reason": "string"}]
+  "minor_count": "integer",
+  "fixed_in_pipeline": [{"severity": "critical|important|minor", "summary": "string"}],
+  "deferred":          [{"severity": "critical|important|minor", "summary": "string", "reason": "string"}]
 }
 ```
 
@@ -46,14 +46,14 @@ Per #251 Wave 3 phase 5 contract comment (locked before any implementation):
 
 ### Task 1 — Extend validator schema for `code-review`
 
-Add a `SCHEMAS['code-review']` entry to `hooks/scripts/validate-return-contract.js`. Add closed-enum validation for `verdict`. Add per-item validation for `fixed_in_pipeline[]` (each item: `{severity: string ∈ {critical, important, suggestion}, summary: string}`) and `deferred[]` (each item: `{severity: string ∈ {critical, important, suggestion}, summary: string, reason: string}`).
+Add a `SCHEMAS['code-review']` entry to `hooks/scripts/validate-return-contract.js`. Add closed-enum validation for `verdict`. Add per-item validation for `fixed_in_pipeline[]` (each item: `{severity: string ∈ {critical, important, minor}, summary: string}`) and `deferred[]` (each item: `{severity: string ∈ {critical, important, minor}, summary: string, reason: string}`).
 
 **Acceptance Criteria:**
 - [ ] `hooks/scripts/validate-return-contract.js` `SCHEMAS` object contains a `'code-review'` key
-- [ ] The schema declares 10 fields: `schema_version`, `phase`, `status`, `verdict`, `report_path`, `critical_count`, `important_count`, `suggestion_count`, `fixed_in_pipeline`, `deferred`
+- [ ] The schema declares 10 fields: `schema_version`, `phase`, `status`, `verdict`, `report_path`, `critical_count`, `important_count`, `minor_count`, `fixed_in_pipeline`, `deferred`
 - [ ] Validator code includes a closed-enum check rejecting any `verdict` value other than `approve`, `needs_changes`, `blocked`
-- [ ] Validator code includes a per-item check for `fixed_in_pipeline[]`: each item must be an object with string fields `severity`, `summary`; `severity` must be one of `critical | important | suggestion`
-- [ ] Validator code includes a per-item check for `deferred[]`: each item must be an object with string fields `severity`, `summary`, `reason`; `severity` must be one of `critical | important | suggestion`
+- [ ] Validator code includes a per-item check for `fixed_in_pipeline[]`: each item must be an object with string fields `severity`, `summary`; `severity` must be one of `critical | important | minor`
+- [ ] Validator code includes a per-item check for `deferred[]`: each item must be an object with string fields `severity`, `summary`, `reason`; `severity` must be one of `critical | important | minor`
 - [ ] Running `node hooks/scripts/validate-return-contract.js hooks/scripts/fixtures/valid-code-review.json` exits 0 (after Task 2 ships the fixture)
 
 ### Task 2 — Add fixture and unit tests for `code-review` schema
@@ -63,7 +63,7 @@ Create a valid fixture and extend the validator unit tests with code-review cove
 **Acceptance Criteria:**
 - [ ] File exists at `hooks/scripts/fixtures/valid-code-review.json`
 - [ ] Fixture's `phase` field is the string `"code-review"`
-- [ ] Fixture has `verdict: "approve"`, `critical_count: 0`, `important_count: 0`, `suggestion_count: 0`, `fixed_in_pipeline: []`, `deferred: []` (clean success case)
+- [ ] Fixture has `verdict: "approve"`, `critical_count: 0`, `important_count: 0`, `minor_count: 0`, `fixed_in_pipeline: []`, `deferred: []` (clean success case)
 - [ ] `hooks/scripts/validate-return-contract.test.js` defines a `VALID_CR` constant with all 10 fields
 - [ ] Test "code-review: valid contract exits 0" passes
 - [ ] Test "code-review: missing required field exits 1" passes (delete `verdict`)

--- a/hooks/scripts/fixtures/valid-code-review.json
+++ b/hooks/scripts/fixtures/valid-code-review.json
@@ -6,7 +6,7 @@
   "report_path": "/tmp/ff-code-review-report-0380.md",
   "critical_count": 0,
   "important_count": 0,
-  "suggestion_count": 0,
+  "minor_count": 0,
   "fixed_in_pipeline": [],
   "deferred": []
 }

--- a/hooks/scripts/fixtures/valid-code-review.json
+++ b/hooks/scripts/fixtures/valid-code-review.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "phase": "code-review",
+  "status": "success",
+  "verdict": "approve",
+  "report_path": "/tmp/ff-code-review-report-0380.md",
+  "critical_count": 0,
+  "important_count": 0,
+  "suggestion_count": 0,
+  "fixed_in_pipeline": [],
+  "deferred": []
+}

--- a/hooks/scripts/validate-return-contract.e2e.sh
+++ b/hooks/scripts/validate-return-contract.e2e.sh
@@ -161,7 +161,8 @@ echo "  e2e PASS (design-document Pattern B): consolidator → state-file → or
 # ----------------------------------------------------------------------------
 
 VAC_CONTRACT_JSON="/tmp/ff-verify-ac-contract-${SLUG}.json"
-trap 'rm -f "$STATE_FILE" "$CONTRACT_JSON" "$DD_CONTRACT_JSON" "$VAC_CONTRACT_JSON"' EXIT
+CR_CONTRACT_JSON="/tmp/ff-code-review-contract-${SLUG}.json"
+trap 'rm -f "$STATE_FILE" "$CONTRACT_JSON" "$DD_CONTRACT_JSON" "$VAC_CONTRACT_JSON" "$CR_CONTRACT_JSON"' EXIT
 
 # Step 8 (Pattern B): consolidator subagent writes verify-acceptance-criteria
 # return contract directly to the tmp JSON path. Mirrors the Step 6 helper
@@ -189,3 +190,44 @@ json.dump(contract, open(os.environ["F"], "w"))
 node "${SCRIPT_DIR}/validate-return-contract.js" "$VAC_CONTRACT_JSON"
 
 echo "  e2e PASS (verify-acceptance-criteria Pattern B): consolidator → tmp-json → validator pipeline works (no state-file)"
+
+# ----------------------------------------------------------------------------
+# Pattern B round-trip — code-review (Wave 3 phase 5, #251)
+# Architectural deviation: this contract is written DIRECTLY to a tmp JSON
+# file by the consolidator subagent. There is no state-file mediation — same
+# bucket-skip rationale as verify-acceptance-criteria above (the four buckets
+# are claimed; the natural `implementation` slot is reserved for future
+# Phase 6 subagent-driven-development). See "Code Review — Pattern B Dispatch"
+# in skills/start/SKILL.md for full rationale.
+# ----------------------------------------------------------------------------
+
+# Step 10 (Pattern B): consolidator subagent writes code-review return
+# contract directly to the tmp JSON path. Mirrors the Phase 5 Contract Write
+# helper in skills/start/references/code-review-pipeline.md exactly (no
+# PHASE_ID — no bucket — contract `phase` field hardcoded to the lifecycle
+# step name `code-review`).
+F="$CR_CONTRACT_JSON" STATUS="success" VERDICT="approve" \
+REPORT="/tmp/ff-code-review-report-${SLUG}.md" \
+CRIT="0" IMP="0" SUG="0" \
+FIXED='[]' DEFERRED='[]' python3 -c '
+import os, json
+contract = {
+    "schema_version": 1,
+    "phase": "code-review",  # lifecycle step name per #251 — there is no bucket
+    "status": os.environ["STATUS"],
+    "verdict": os.environ["VERDICT"],
+    "report_path": os.environ["REPORT"],
+    "critical_count": int(os.environ["CRIT"]),
+    "important_count": int(os.environ["IMP"]),
+    "suggestion_count": int(os.environ["SUG"]),
+    "fixed_in_pipeline": json.loads(os.environ["FIXED"]),
+    "deferred": json.loads(os.environ["DEFERRED"]),
+}
+json.dump(contract, open(os.environ["F"], "w"))
+'
+
+# Step 11 (Pattern B): orchestrator validator (no read-helper step — the
+# consolidator wrote directly to the tmp path, no state-file extraction).
+node "${SCRIPT_DIR}/validate-return-contract.js" "$CR_CONTRACT_JSON"
+
+echo "  e2e PASS (code-review Pattern B): consolidator → tmp-json → validator pipeline works (no state-file)"

--- a/hooks/scripts/validate-return-contract.e2e.sh
+++ b/hooks/scripts/validate-return-contract.e2e.sh
@@ -208,7 +208,7 @@ echo "  e2e PASS (verify-acceptance-criteria Pattern B): consolidator → tmp-js
 # step name `code-review`).
 F="$CR_CONTRACT_JSON" STATUS="success" VERDICT="approve" \
 REPORT="/tmp/ff-code-review-report-${SLUG}.md" \
-CRIT="0" IMP="0" SUG="0" \
+CRIT="0" IMP="0" MIN="0" \
 FIXED='[]' DEFERRED='[]' python3 -c '
 import os, json
 contract = {
@@ -219,7 +219,7 @@ contract = {
     "report_path": os.environ["REPORT"],
     "critical_count": int(os.environ["CRIT"]),
     "important_count": int(os.environ["IMP"]),
-    "suggestion_count": int(os.environ["SUG"]),
+    "minor_count": int(os.environ["MIN"]),
     "fixed_in_pipeline": json.loads(os.environ["FIXED"]),
     "deferred": json.loads(os.environ["DEFERRED"]),
 }

--- a/hooks/scripts/validate-return-contract.js
+++ b/hooks/scripts/validate-return-contract.js
@@ -39,9 +39,29 @@ const SCHEMAS = {
     fail_count: 'number',
     failed_criteria: 'array',
   },
+  // Wave 3 phase 5 (#251) — Pattern B. Bucket-skip variant — same shape as
+  // verify-acceptance-criteria above. Contract is written directly to a tmp
+  // JSON file by the consolidator subagent; code-review is a verification
+  // step within the implementation phase, not a phase that owns a bucket.
+  'code-review': {
+    schema_version: 'number',
+    phase: 'string',
+    status: 'string',
+    verdict: 'string',
+    report_path: 'string',
+    critical_count: 'number',
+    important_count: 'number',
+    suggestion_count: 'number',
+    fixed_in_pipeline: 'array',
+    deferred: 'array',
+  },
 };
 
 const FAILED_CRITERIA_ITEM_FIELDS = ['task_id', 'criterion', 'reason'];
+const FIXED_IN_PIPELINE_ITEM_FIELDS = ['severity', 'summary'];
+const DEFERRED_ITEM_FIELDS = ['severity', 'summary', 'reason'];
+const VALID_VERDICTS = new Set(['approve', 'needs_changes', 'blocked']);
+const VALID_SEVERITIES = new Set(['critical', 'important', 'suggestion']);
 
 const VALID_STATUSES = new Set(['success', 'partial', 'failed']);
 
@@ -103,6 +123,51 @@ function validate(phaseId, obj) {
       if (badField) {
         errors.push(`failed_criteria: each item must have string fields ${FAILED_CRITERIA_ITEM_FIELDS.join(', ')} (missing or non-string: ${badField})`);
         break;
+      }
+    }
+  }
+  if (!errors.length && phaseId === 'code-review') {
+    if (!VALID_VERDICTS.has(obj.verdict)) {
+      errors.push(`verdict: expected one of approve|needs_changes|blocked, got "${obj.verdict}"`);
+    }
+    if (!errors.length && Array.isArray(obj.fixed_in_pipeline)) {
+      for (const item of obj.fixed_in_pipeline) {
+        if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+          errors.push('fixed_in_pipeline: all items must be objects');
+          break;
+        }
+        let badField = null;
+        for (const f of FIXED_IN_PIPELINE_ITEM_FIELDS) {
+          if (typeof item[f] !== 'string') { badField = f; break; }
+        }
+        if (badField) {
+          errors.push(`fixed_in_pipeline: each item must have string fields ${FIXED_IN_PIPELINE_ITEM_FIELDS.join(', ')} (missing or non-string: ${badField})`);
+          break;
+        }
+        if (!VALID_SEVERITIES.has(item.severity)) {
+          errors.push(`fixed_in_pipeline: severity must be one of critical|important|suggestion, got "${item.severity}"`);
+          break;
+        }
+      }
+    }
+    if (!errors.length && Array.isArray(obj.deferred)) {
+      for (const item of obj.deferred) {
+        if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+          errors.push('deferred: all items must be objects');
+          break;
+        }
+        let badField = null;
+        for (const f of DEFERRED_ITEM_FIELDS) {
+          if (typeof item[f] !== 'string') { badField = f; break; }
+        }
+        if (badField) {
+          errors.push(`deferred: each item must have string fields ${DEFERRED_ITEM_FIELDS.join(', ')} (missing or non-string: ${badField})`);
+          break;
+        }
+        if (!VALID_SEVERITIES.has(item.severity)) {
+          errors.push(`deferred: severity must be one of critical|important|suggestion, got "${item.severity}"`);
+          break;
+        }
       }
     }
   }

--- a/hooks/scripts/validate-return-contract.js
+++ b/hooks/scripts/validate-return-contract.js
@@ -51,7 +51,7 @@ const SCHEMAS = {
     report_path: 'string',
     critical_count: 'number',
     important_count: 'number',
-    suggestion_count: 'number',
+    minor_count: 'number',
     fixed_in_pipeline: 'array',
     deferred: 'array',
   },
@@ -61,7 +61,7 @@ const FAILED_CRITERIA_ITEM_FIELDS = ['task_id', 'criterion', 'reason'];
 const FIXED_IN_PIPELINE_ITEM_FIELDS = ['severity', 'summary'];
 const DEFERRED_ITEM_FIELDS = ['severity', 'summary', 'reason'];
 const VALID_VERDICTS = new Set(['approve', 'needs_changes', 'blocked']);
-const VALID_SEVERITIES = new Set(['critical', 'important', 'suggestion']);
+const VALID_SEVERITIES = new Set(['critical', 'important', 'minor']);
 
 const VALID_STATUSES = new Set(['success', 'partial', 'failed']);
 
@@ -145,7 +145,7 @@ function validate(phaseId, obj) {
           break;
         }
         if (!VALID_SEVERITIES.has(item.severity)) {
-          errors.push(`fixed_in_pipeline: severity must be one of critical|important|suggestion, got "${item.severity}"`);
+          errors.push(`fixed_in_pipeline: severity must be one of critical|important|minor, got "${item.severity}"`);
           break;
         }
       }
@@ -165,7 +165,7 @@ function validate(phaseId, obj) {
           break;
         }
         if (!VALID_SEVERITIES.has(item.severity)) {
-          errors.push(`deferred: severity must be one of critical|important|suggestion, got "${item.severity}"`);
+          errors.push(`deferred: severity must be one of critical|important|minor, got "${item.severity}"`);
           break;
         }
       }

--- a/hooks/scripts/validate-return-contract.test.js
+++ b/hooks/scripts/validate-return-contract.test.js
@@ -235,7 +235,7 @@ const VALID_CR = {
   report_path: '/tmp/ff-code-review-report-0380.md',
   critical_count: 0,
   important_count: 0,
-  suggestion_count: 0,
+  minor_count: 0,
   fixed_in_pipeline: [],
   deferred: []
 };
@@ -290,7 +290,7 @@ test('code-review: needs_changes verdict with non-empty fixed_in_pipeline + defe
     verdict: 'needs_changes',
     critical_count: 1,
     important_count: 2,
-    suggestion_count: 0,
+    minor_count: 0,
     fixed_in_pipeline: [
       { severity: 'important', summary: 'tightened input validation in foo.ts' },
       { severity: 'important', summary: 'removed silent catch in bar.ts' }

--- a/hooks/scripts/validate-return-contract.test.js
+++ b/hooks/scripts/validate-return-contract.test.js
@@ -226,5 +226,83 @@ test('verify-acceptance-criteria: failed status is valid', () => {
   if (r.code !== 0) throw new Error(`expected exit 0 for failed status; got ${r.code}\n${r.stderr}`);
 });
 
+// code-review tests (Wave 3 phase 5 — Pattern B, #251)
+const VALID_CR = {
+  schema_version: 1,
+  phase: 'code-review',
+  status: 'success',
+  verdict: 'approve',
+  report_path: '/tmp/ff-code-review-report-0380.md',
+  critical_count: 0,
+  important_count: 0,
+  suggestion_count: 0,
+  fixed_in_pipeline: [],
+  deferred: []
+};
+
+test('code-review: valid contract exits 0', () => {
+  const p = writeFixture(VALID_CR);
+  const r = run(p);
+  if (r.code !== 0) throw new Error(`expected exit 0, got ${r.code}\n${r.stderr}`);
+});
+
+test('code-review: missing required field exits 1', () => {
+  const bad = { ...VALID_CR }; delete bad.verdict;
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for missing verdict');
+  if (!r.stdout.includes('missing required field')) throw new Error(`expected "missing required field" in output; got: ${r.stdout}`);
+});
+
+test('code-review: invalid verdict value exits 1', () => {
+  const bad = { ...VALID_CR, verdict: 'approved' };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for invalid verdict enum');
+  if (!r.stdout.includes('verdict')) throw new Error(`expected verdict error in output; got: ${r.stdout}`);
+});
+
+test('code-review: fixed_in_pipeline with non-object item exits 1', () => {
+  const bad = { ...VALID_CR, status: 'partial', fixed_in_pipeline: ['critical: foo'] };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for string item in fixed_in_pipeline');
+});
+
+test('code-review: fixed_in_pipeline with bad severity exits 1', () => {
+  const bad = { ...VALID_CR, status: 'partial', fixed_in_pipeline: [{ severity: 'high', summary: 'x' }] };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for invalid severity in fixed_in_pipeline');
+});
+
+test('code-review: deferred missing reason exits 1', () => {
+  const bad = { ...VALID_CR, status: 'partial', verdict: 'needs_changes', deferred: [{ severity: 'critical', summary: 'x' }] };
+  const p = writeFixture(bad);
+  const r = run(p);
+  if (r.code === 0) throw new Error('expected non-zero exit for deferred item missing reason');
+});
+
+test('code-review: needs_changes verdict with non-empty fixed_in_pipeline + deferred is valid', () => {
+  const partial = {
+    ...VALID_CR,
+    status: 'partial',
+    verdict: 'needs_changes',
+    critical_count: 1,
+    important_count: 2,
+    suggestion_count: 0,
+    fixed_in_pipeline: [
+      { severity: 'important', summary: 'tightened input validation in foo.ts' },
+      { severity: 'important', summary: 'removed silent catch in bar.ts' }
+    ],
+    deferred: [
+      { severity: 'critical', summary: 'pr-test-analyzer flagged missing edge case', reason: 'agent re-dispatch unavailable in Pattern B consolidator' }
+    ]
+  };
+  const p = writeFixture(partial);
+  const r = run(p);
+  if (r.code !== 0) throw new Error(`expected exit 0 for needs_changes with valid items; got ${r.code}\n${r.stderr}`);
+});
+
 console.log(`\nResults: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -680,7 +680,7 @@ Runs inline as a Bash call paired with the TaskUpdate. The `$(cd "$(git rev-pars
 - **Pattern A (wrap):** orchestrator dispatches one Task subagent that invokes the phase skill and returns a structured contract. Used for phases that do NOT internally fan out subagents.
 - **Pattern B (hoist + consolidator):** orchestrator dispatches the parallel fanout itself (subagents cannot dispatch sub-subagents per #251 Q1), then dispatches a single consolidator subagent that ingests fanout results, runs the rest of the skill, and returns a structured contract. Used for phases that DO internally fan out.
 
-Currently converted: `verify-plan-criteria` (Pattern A — see "Verify Plan Criteria — Pattern A Dispatch" subsection below), `design-document` (Pattern B — see "Design Document — Pattern B Dispatch" subsection below), `verify-acceptance-criteria` (Pattern B — see "Verify Acceptance Criteria — Pattern B Dispatch" subsection below). Skipped by design analysis: `merge-prs` (no orchestrator-side benefit; see issue #251 comment). Future conversions: `code-review`, `implementation` per #251's conversion order. Each converted phase has its own wrapper subsection documenting the dispatch shape, return-contract validation, and inline-fallback path. **In Express and Interactive modes, Pattern A and Pattern B still apply** — the skills being wrapped do not require user interaction at the points where dispatch happens, so subagent isolation is safe in all modes.
+Currently converted: `verify-plan-criteria` (Pattern A — see "Verify Plan Criteria — Pattern A Dispatch" subsection below), `design-document` (Pattern B — see "Design Document — Pattern B Dispatch" subsection below), `verify-acceptance-criteria` (Pattern B — see "Verify Acceptance Criteria — Pattern B Dispatch" subsection below), `code-review` (Pattern B — see "Code Review — Pattern B Dispatch" subsection below). Skipped by design analysis: `merge-prs` (no orchestrator-side benefit; see issue #251 comment). Future conversions: `implementation` per #251's conversion order. Each converted phase has its own wrapper subsection documenting the dispatch shape, return-contract validation, and inline-fallback path. **In Express and Interactive modes, Pattern A and Pattern B still apply** — the skills being wrapped do not require user interaction at the points where dispatch happens, so subagent isolation is safe in all modes.
 
 **Why:** The `Skill` tool has no `model` parameter — it inherits the parent model. The `Task` tool has an explicit `model` parameter. In YOLO mode there is no user interaction, so running skills inside a Task subagent works identically to running them inline. The `/model` command must NEVER be used — it writes to `~/.claude/settings.json` (a global config file) and affects all other terminal windows and tmux panes.
 
@@ -939,6 +939,88 @@ Task(
 
 **Call site:** the Pattern B wrapper is invoked from the Final Verification inline step (`skills/start/references/inline-steps.md` "Final Verification Step" section). The "Always run verify-acceptance-criteria" rule there now resolves to "Always run verify-acceptance-criteria via Pattern B dispatch" — see that section for integration with the quality-gate-skip logic.
 
+### Code Review — Pattern B Dispatch
+
+**Note:** INLINE-FALLBACK IS A ROLLOUT-ONLY FEATURE.
+<!-- feature-flow vNEXT+1 removes inline-fallback once two consecutive successful real-session uses are observed. -->
+
+**Applies in ALL modes** (YOLO, Express, Interactive — see the "Subagent dispatch patterns A and B" CRITICAL block above) at every scope where the existing pipeline runs (Small enhancement, Feature, Major feature — Quick fix is already skipped per `skills/start/references/code-review-pipeline.md` "Quick fix guard"). `code-review` is the third Pattern B conversion (per #251 Wave 3 phase 5). The pipeline internally fans out the parallel reviewer dispatches across Phase 1a (pr-review-toolkit), Phase 1b (report-only agents), and Phase 1c (senior panel). Subagents cannot recursively dispatch (#251 Q1), so the orchestrator continues to dispatch those reviewer fanouts itself, then dispatches a single consolidator subagent that runs Phases 2-5 in isolation: conflict detection, fix application, targeted re-verification, report assembly, and contract write. The orchestrator never sees the reviewer findings list, the conflict-resolution decisions, or the fix-application diff — only the validated return contract.
+
+**Why skip the state-file bucket** (architectural deviation — same rationale as `verify-acceptance-criteria`): the four `phase_summaries` buckets (`brainstorm`, `design`, `plan`, `implementation`) are all claimed by phase-boundary writes. Code-review is a verification step within the implementation phase, not a phase that owns a bucket. Reusing `phase_summaries.implementation.return_contract` would collide with the future Phase 6 (`subagent-driven-development`) Pattern B contract. The contract is consumed once by the orchestrator's validator and discarded — no cross-compaction reader needs it from the state file. Writing directly to a tmp JSON file avoids the collision and avoids a schema_version bump.
+
+**Sub-step 1 — Phase 0 deterministic pre-filter (orchestrator-side, unchanged):**
+
+The orchestrator runs the existing Phase 0 logic from `skills/start/references/code-review-pipeline.md` — detect TypeScript / ESLint / Biome, run them in parallel, fix deterministic findings, build the exclusion-context summary. No subagent dispatch yet. Phase 0 is fast (linters) and produces a small text output; isolating it in a subagent is not load-bearing.
+
+**Sub-step 2 — Phase 1a/1b/1c parallel reviewer dispatches (orchestrator-side, unchanged):**
+
+The orchestrator dispatches the existing reviewers per the existing rules in `skills/start/references/code-review-pipeline.md` — Phase 1a pr-review-toolkit subagent (gated, sequential pre-pass), then Phase 1b report-only agents in parallel with Phase 1c senior panel (Major-feature only). These dispatches MUST stay orchestrator-side because subagents cannot recursively dispatch (#251 Q1). The orchestrator collects each reviewer's structured output (Phase 1a Auto-Fixed/Critical/Important/Minor sections; Phase 1b structured findings; Phase 1c findings + persona/finding_type fields).
+
+**Sub-step 3 — Consolidator dispatch:**
+
+```
+SLUG=<slug-from-session-context>
+LIFECYCLE_SESSION=<lifecycle-session-slug-from-.feature-flow/session.txt>
+CONTRACT_PATH="/tmp/ff-code-review-contract-${SLUG}.json"
+REPORT_PATH="/tmp/ff-code-review-report-${SLUG}.md"
+PLAN_FILE="<absolute path to plan>"
+
+Task(
+  subagent_type: "general-purpose",
+  model: "sonnet",
+  description: "code-review Pattern B consolidator",
+  prompt: "Run Phases 2-5 of the code-review pipeline per `skills/start/references/code-review-pipeline.md`. You are receiving the parallel reviewer outputs from the orchestrator (which already executed Phases 0, 1a, 1b, 1c).
+
+Inputs:
+- Phase 1a pr-review-toolkit summary: <inline structured summary OR null if Phase 1a was skipped>
+- Phase 1b structured findings: <inline list per agent>
+- Phase 1c senior panel findings: <inline list OR empty list when scope < Major feature OR null when Phase 1c failed>
+- Lifecycle session slug: ${LIFECYCLE_SESSION}
+- Plan file (for the verdict-honesty constraint context): ${PLAN_FILE}
+- Report path to write: ${REPORT_PATH}
+- Contract path to write: ${CONTRACT_PATH}
+
+Execute Phase 2 (merge / dedupe / conflict-detect), Phase 3 (apply rule-based fixes via Edit/Write/Bash and commit), Phase 4 (targeted re-verification — for any agent re-dispatch row that triggers, write a deferred[] entry instead per the Pattern B agent-re-dispatch rule in code-review-pipeline.md), Phase 5 (write the report to ${REPORT_PATH} with [session:${LIFECYCLE_SESSION}] correlation tokens on every entry, then write the return contract to ${CONTRACT_PATH} per the Phase 5 'Contract Write' subsection). Return the contract path and a one-line verdict summary."
+)
+```
+
+**Why `model: "sonnet"`:** consolidation requires structured-output discipline (deduplication, conflict detection, contract field assembly) plus mechanical edits (Phase 3 fix application). Sonnet handles both well; Haiku is too brittle for the conflict-resolution heuristics; Opus is over-spec for what is mostly bookkeeping over already-produced findings. Senior-panel dispatches (Phase 1c) already use Opus at the orchestrator level; the consolidator does not need to re-decide architectural questions, only consolidate.
+
+**Post-dispatch sequence (orchestrator-side):**
+
+1. **Verify the contract file was written:**
+   ```bash
+   [ -f "${CONTRACT_PATH}" ] && echo ok || echo missing
+   ```
+   If `missing` → trigger **inline-fallback** (case 3 below).
+2. **Validate the contract:**
+   ```bash
+   node hooks/scripts/validate-return-contract.js "${CONTRACT_PATH}"
+   ```
+   Exit 0 → proceed. Non-zero → trigger **inline-fallback** (case 4 below).
+3. **Read `verdict` from the validated contract** and feed the lifecycle decision:
+   - `verdict: "approve"` → continue normally to next lifecycle step (Generate CHANGELOG entry / Final verification).
+   - `verdict: "needs_changes"` → continue but flag the PR; the post-implementation comment and PR body should reflect that critical/important findings remain. The lifecycle does not auto-halt — the user makes the merge decision.
+   - `verdict: "blocked"` → halt the lifecycle. Surface the contract's `deferred[]` entries to the user and stop. Do not proceed to commit/PR.
+
+**Inline-fallback path** (rollout-only — four failure cases):
+
+| Case | Trigger | Announce | Next |
+|------|---------|----------|------|
+| 1 | Sub-step 2 reviewer dispatch failure (existing per-reviewer handlers retained — this row covers cascading failures only) | `code-review Pattern B: reviewer dispatch failed (<reason>). Continuing inline at orchestrator level.` | Run Phases 2-5 inline at the orchestrator level per `skills/start/references/code-review-pipeline.md` |
+| 2 | Consolidator `Task()` dispatch fails (timeout, tool error, refusal) | `code-review Pattern B: consolidator dispatch failed (<reason>). Falling back to inline pipeline.` | Run Phases 2-5 inline at the orchestrator level (orchestrator can do agent re-dispatch in Phase 4 — no `deferred[]` mapping needed in fallback path) |
+| 3 | Consolidator completes but `write_contract_to` JSON file is missing or empty | `code-review Pattern B: consolidator did not write contract. Falling back to inline pipeline.` | Same inline pipeline path |
+| 4 | `validate-return-contract.js` exits non-zero | `code-review Pattern B: contract validation failed (<error from validator>). Falling back to inline pipeline.` | Same inline pipeline path |
+
+**The inline-fallback target is the existing in-place pipeline** — Phases 2-5 run at the orchestrator level identically to the pre-#251 behavior. Phase 4 agent re-dispatch works in the inline path (orchestrator CAN dispatch agents); no `deferred[]` entries are written in fallback mode.
+
+<!-- SUNSET NOTE: feature-flow vNEXT+1 removes this inline-fallback table and the four failure-case
+     handlers once two consecutive successful real-session uses of Pattern B are observed and the
+     measurement (per #253) confirms ≥5% orchestrator context reduction. The wrapper itself stays;
+     only the fallback safety net is sunset. -->
+
+**Call site:** the Pattern B wrapper is invoked from the Code Review Pipeline Step (`skills/start/SKILL.md` "Code Review Pipeline Step" section, which itself defers to `skills/start/references/code-review-pipeline.md`). The "Quick fix guard" at the top of that pipeline doc still applies — Quick fix scope skips both Pattern B and the inline pipeline.
+
 **Lifecycle Context Object:** As the lifecycle executes, maintain a context object that accumulates artifact paths as they become known. Include all known paths in the `args` of every subsequent `Skill` invocation, after the mode flag and scope:
 
 | Path key | When it becomes available |
@@ -1025,7 +1107,7 @@ If the in-progress file does not exist (initial write failed), skip phase-bounda
 | Copy env files | No skill — inline step (see below) | Env files available in worktree |
 | Implement | `superpowers:subagent-driven-development` | Code written with tests, spec-reviewed, and quality-reviewed per task |
 | Self-review | No skill — inline step (see below) | Code verified against coding standards before formal review |
-| Code review | No skill — inline step (see below) | All Critical/Important findings fixed, tests pass |
+| Code review | No skill — inline step (see below). Invoked via Pattern B dispatch — orchestrator-side Phase 0 + Phase 1a/1b/1c parallel reviewer dispatches + consolidator `Task()` with `model: "sonnet"` running Phases 2-5; structured return contract written directly to `/tmp/ff-code-review-contract-<slug>.json` — **no state-file bucket**, see "Code Review — Pattern B Dispatch" section above; inline-fallback path retained for rollout. Pattern B applies in all modes (YOLO, Express, Interactive). | All Critical/Important findings fixed (or surfaced as `deferred[]` for the verdict honesty check), tests pass; `verdict ∈ {approve, needs_changes}` returned via validated contract — `verdict: "blocked"` halts the lifecycle; return contract validated via `hooks/scripts/validate-return-contract.js` |
 | Generate CHANGELOG entry | No skill — inline step (see below) | Changelog fragment written to `.changelogs/<id>.md`; consolidated when `/merge-prs` is invoked |
 | Final verification | No skill — inline step (see below). Calls `feature-flow:verify-acceptance-criteria` (invoked via Pattern B dispatch — orchestrator-side hoisted task-verifier `Task()` with `model: "haiku"` + consolidator `Task()` with `model: "sonnet"`; structured return contract written directly to a tmp JSON path — **no state-file bucket**, see "Verify Acceptance Criteria — Pattern B Dispatch" section above; inline-fallback path retained for rollout) | All criteria PASS + quality gates pass (or skipped if Phase 4 already passed); return contract validated via `hooks/scripts/validate-return-contract.js` |
 | Sync with base branch | No skill — inline step (see below) | Branch merged onto latest base branch; conflicts require manual resolution |

--- a/skills/start/references/code-review-pipeline.md
+++ b/skills/start/references/code-review-pipeline.md
@@ -214,6 +214,23 @@ A single opus subagent orchestrates three personas sequentially (Staff Engineer 
 
 All failure announcements include the `[session:$LIFECYCLE_SESSION]` correlation token.
 
+## Pattern B handoff (orchestrator → consolidator)
+
+As of Wave 3 phase 5 (#251), Phases 2-5 run inside a **consolidator subagent** (Pattern B). The orchestrator continues to own Phases 0, 1a, 1b, and 1c (subagents cannot recursively dispatch per #251 Q1, so the parallel reviewer fanout MUST stay orchestrator-side). The orchestrator then dispatches a single `general-purpose` consolidator subagent (`model: "sonnet"`) that ingests the reviewer outputs, runs Phases 2-5 in isolation, writes the report, and writes the structured return contract.
+
+**Consolidator inputs (passed in dispatch prompt):**
+
+1. The Phase 1a pr-review-toolkit summary (Auto-Fixed / Critical / Important / Minor sections, or the `null` sentinel if Phase 1a was skipped).
+2. The Phase 1b structured findings list from each report-only agent that ran (or empty list if none ran / all skipped).
+3. The Phase 1c senior panel findings list (or empty list when scope < Major feature, or `null` when Phase 1c failed under one of the four dispositions).
+4. The `lifecycle_session` slug (`YYYY-MM-DD-<kebab-slug>` from `.feature-flow/session.txt`). Every Phase 5 report entry the consolidator emits MUST carry the `[session:$LIFECYCLE_SESSION]` correlation token — the same requirement that already applies in inline mode, preserved across the handoff so grep-correlation across pipeline phases, the Phase 5 report, and the PR body still works.
+
+**Consolidator owns Phases 2, 3, 4, 5 + contract write.** Specifically: Phase 2 (merge / dedupe / conflict detection), Phase 3 (apply rule-based fixes via Edit/Write/Bash + commit), Phase 4 (targeted re-verification — see Pattern B caveats below), Phase 5 (report + contract write).
+
+**Pattern B Phase 4 caveat — agent re-dispatch unavailable:** the consolidator has Edit/Write/Bash/Skill but cannot dispatch `Agent`/`Task` subagents (#251 Q1). Each Phase 4 row that would normally trigger an agent re-dispatch instead writes a `deferred[]` entry to the return contract with `reason: "agent re-dispatch unavailable in Pattern B consolidator"`. See Phase 4 below for the full rule and the verdict-honesty constraint that follows.
+
+**Inline-fallback (rollout-only):** see "Code Review — Pattern B Dispatch" in `skills/start/SKILL.md`. The fallback runs the same Phases 2-5 inline at the orchestrator level, identically to the pre-#251 behavior.
+
 ## Phase 2: Conflict Detection
 
 After all Phase 1b agents complete, consolidate findings from both phases and detect conflicts before applying fixes.
@@ -294,21 +311,20 @@ From the Phase 3 fix log, identify which targeted checks apply. Multiple checks 
 | If this was true in Phase 3… | Run this targeted check |
 |------------------------------|-------------------------|
 | `pr-test-analyzer` had Critical/Important findings | Run the project test suite |
-| `superpowers:code-reviewer` flagged rule 6 ("all acceptance criteria met") | Run `verify-acceptance-criteria` |
-| Any *other* reporting agent (not covered by rows above) had Critical/Important findings | Re-dispatch ONLY that specific agent on changed files only (`git diff [base-branch]...HEAD`) |
+| Any *other* reporting agent (not `pr-test-analyzer`, not covered by rows above) had Critical/Important findings | **Pattern B:** record a `deferred[]` entry per finding (see "Pattern B agent-re-dispatch rule" below). **Inline fallback:** re-dispatch ONLY that specific agent on changed files (`git diff [base-branch]...HEAD`). |
 | `silent-failure-hunter` or `code-simplifier` made direct fixes | Read back the changed files to confirm the fix is correct (no regression, no silent swallow introduced) |
-| No Critical/Important findings from any agent (all clean) | Run `verify-acceptance-criteria` only as a baseline sanity check |
 
-*Note: Rows are evaluated top-to-bottom; a more specific row takes precedence over the catch-all (row 3). Multiple non-overlapping rows may apply — run all matching targeted checks.*
+*Note: Rows are evaluated top-to-bottom; a more specific row takes precedence over the catch-all. Multiple non-overlapping rows may apply — run all matching targeted checks. The previous `superpowers:code-reviewer rule 6 → run verify-acceptance-criteria` row and the previous `No Critical/Important findings → run verify-acceptance-criteria as baseline sanity check` row were both deleted in Wave 3 phase 5 (#251): the Final Verification inline step (`skills/start/references/inline-steps.md` "Final Verification Step") runs verify-acceptance-criteria immediately after the code-review step, making both invocations redundant.*
+
+**Pattern B agent-re-dispatch rule:** inside the consolidator, `Agent`/`Task` dispatch is unavailable (#251 Q1 — recursive dispatch fails silently). For every Phase 4 row above that would normally trigger an agent re-dispatch, the consolidator writes one `deferred[]` entry to the return contract per affected finding, with `severity` carried over from the original finding and `reason: "agent re-dispatch unavailable in Pattern B consolidator"`. **Verdict honesty constraint:** the consolidator MUST NOT return `verdict: "approve"` while `deferred[]` is non-empty due to agent re-dispatch unavailability; if any critical or important finding is in `deferred[]`, the verdict MUST be at least `needs_changes`. (Inline-fallback mode runs the actual re-dispatch; no `deferred[]` entries are written in that path.)
 
 **Step 2: Run targeted checks (parallel where possible)**
 
 Run only the targeted checks from Step 1. Announce which checks are being run: "Targeted re-verification: [check list]."
 
-- **Tests:** Detect test runner from project (`package.json` scripts.test → `npm test` | `Cargo.toml` → `cargo test` | `go.mod` → `go test ./...` | `mix.exs` → `mix test` | `pyproject.toml`/`pytest.ini`/`setup.cfg`/`tox.ini` → `python -m pytest` | `deno.json`/`deno.jsonc` → `deno test` | `bun.lockb`/`bun.lock`/`bunfig.toml` → `bun test`). If no runner detected, skip with log: "No test runner detected — skipping." If runner is detected but the binary is not installed (ENOENT / exit code 127), log a warning and skip: "Test binary not installed — skipping test verification." Do not count a missing binary as a test failure. Timeout: 60 seconds — if the suite times out, log a warning and skip (do not count as a failure).
-- **verify-acceptance-criteria:** Run the `feature-flow:verify-acceptance-criteria` skill with the plan file path.
-- **Agent re-dispatch:** Dispatch only the specific agent(s) that had Critical/Important findings, with `git diff [base-branch]...HEAD` for context. Use the same model as the original Phase 1b dispatch. All re-dispatched agents launch in a single parallel message. If an agent crashes or produces no output, do not treat it as clean — log: "Agent [name] re-dispatch produced no result — listing as unresolved in Phase 5."
-- **Read-back verification:** Read the specific files modified by direct-fix agents and confirm the fix is syntactically correct and no regression is visible.
+- **Tests:** Detect test runner from project (`package.json` scripts.test → `npm test` | `Cargo.toml` → `cargo test` | `go.mod` → `go test ./...` | `mix.exs` → `mix test` | `pyproject.toml`/`pytest.ini`/`setup.cfg`/`tox.ini` → `python -m pytest` | `deno.json`/`deno.jsonc` → `deno test` | `bun.lockb`/`bun.lock`/`bunfig.toml` → `bun test`). If no runner detected, skip with log: "No test runner detected — skipping." If runner is detected but the binary is not installed (ENOENT / exit code 127), log a warning and skip: "Test binary not installed — skipping test verification." Do not count a missing binary as a test failure. Timeout: 60 seconds — if the suite times out, log a warning and skip (do not count as a failure). Tests run in both Pattern B and inline-fallback paths (Bash works in subagents).
+- **Agent re-dispatch (inline-fallback only):** Dispatch only the specific agent(s) that had Critical/Important findings, with `git diff [base-branch]...HEAD` for context. Use the same model as the original Phase 1b dispatch. All re-dispatched agents launch in a single parallel message. If an agent crashes or produces no output, do not treat it as clean — log: "Agent [name] re-dispatch produced no result — listing as unresolved in Phase 5." **Pattern B path skips this entirely; see "Pattern B agent-re-dispatch rule" above for the `deferred[]` mapping.**
+- **Read-back verification:** Read the specific files modified by direct-fix agents and confirm the fix is syntactically correct and no regression is visible. Read-back runs in both Pattern B and inline-fallback paths.
 
 **Step 3: If all targeted checks pass → pipeline is clean**
 
@@ -323,19 +339,22 @@ If still failing after this additional pass → report remaining issues to the d
 
 **Maximum 2 total fix-verify iterations** after Phase 3 (targeted re-verify → optional 1 additional pass). Stop after 2 iterations — report remaining issues for manual resolution. This cap applies only to rule-based fix-verify loops. Judgment findings from Phase 1c are surfaced once in Phase 5 and do not re-enter the loop.
 
-## Phase 5: Report
+## Phase 5: Report and Contract Write
 
-**Zero-agent guard:** If all tier-selected agents were skipped (plugins unavailable), do not proceed through Phases 1a–4. Announce: "All tier-selected agents for [scope] (Tier T) were unavailable. Code review pipeline could not run — manual review recommended." Skip to Phase 5 and include a warning in the report.
+**Zero-agent guard:** If all tier-selected agents were skipped (plugins unavailable), do not proceed through Phases 1a–4. Announce: "All tier-selected agents for [scope] (Tier T) were unavailable. Code review pipeline could not run — manual review recommended." Skip to Phase 5 and include a warning in the report. In Pattern B, the consolidator still writes a return contract with `verdict: "blocked"`, `status: "failed"`, and a `deferred[]` entry per skipped tier-selected agent.
+
+**Session token requirement:** Every entry the consolidator emits in the report below MUST carry the `[session:$LIFECYCLE_SESSION]` correlation token (the slug passed in via the Pattern B handoff). This is the same requirement that already applies in inline mode, preserved across Pattern B so grep-correlation across pipeline phases, the Phase 5 report, and the PR body still works.
 
 Output a summary:
 
 ```
-## Code Review Pipeline Results
+## Code Review Pipeline Results [session:$LIFECYCLE_SESSION]
 
 **Agents dispatched:** N (Tier T — [scope])
 **Stack filter:** [stack entries used for filtering]
 **Model override:** [None | user-requested: \<model\>]
 **Iterations:** M/2
+**Verdict:** approve | needs_changes | blocked
 
 ### Fixed (pr-review-toolkit pre-pass)
 - [agent] [file:line] [what was auto-fixed]
@@ -368,7 +387,65 @@ Output a summary:
 ### Remaining (unfixed after 2 iterations)
 - [file:line] [description + context for manual resolution]
 
+### Deferred (Pattern B — agent re-dispatch unavailable)
+- [severity] [file:line] [description] — agent re-dispatch unavailable in Pattern B consolidator
+
 **Status:** Clean / N issues remaining
 ```
+
+### Contract Write (Pattern B only)
+
+When invoked from the Pattern B wrapper (`skills/start/SKILL.md` "Code Review — Pattern B Dispatch"), the consolidator receives a `write_contract_to` JSON path in its dispatch prompt. After emitting the report above, write the structured return contract to that path. The contract's `phase` field is hardcoded to `"code-review"` per #251's locked spec — the validator uses this to look up the schema.
+
+**Construct the contract object:**
+
+- `schema_version`: `1`
+- `phase`: hardcoded `"code-review"`
+- `status`: `success` (clean pipeline, all critical+important addressed) | `partial` (deferred entries present OR remaining-after-2-iterations entries present) | `failed` (zero-agent guard fired, or consolidator could not assemble verdict)
+- `verdict`: `approve` (no critical, no `deferred[]`) | `needs_changes` (any critical OR any `deferred[]` present) | `blocked` (zero-agent guard, or pipeline cannot return a verdict)
+- `report_path`: absolute path of the written report
+- `critical_count`, `important_count`, `suggestion_count`: integer counts across the entire pipeline (Phase 1a + 1b + 1c)
+- `fixed_in_pipeline`: array of `{severity: "critical|important|suggestion", summary: "<one-line>"}` for every finding addressed in Phase 1a auto-fix or Phase 3 single-pass fix
+- `deferred`: array of `{severity, summary, reason}` for every Phase 4 row that mapped to deferral, plus any Minor-tier or unfixed-after-2-iterations entry the consolidator chose to surface in the contract
+
+Use the env-var-passing helper pattern (apostrophe-safe; mirrors `skills/verify-acceptance-criteria/SKILL.md` Step 6):
+
+```bash
+F="<write_contract_to value>"
+STATUS="<success|partial|failed>"
+VERDICT="<approve|needs_changes|blocked>"
+REPORT="<absolute path to the written report>"
+CRIT=<integer> IMP=<integer> SUG=<integer>
+FIXED='<json-array-string for fixed_in_pipeline>'
+DEFERRED='<json-array-string for deferred>'
+
+F="$F" STATUS="$STATUS" VERDICT="$VERDICT" REPORT="$REPORT" \
+CRIT="$CRIT" IMP="$IMP" SUG="$SUG" \
+FIXED="$FIXED" DEFERRED="$DEFERRED" python3 -c '
+import os, json
+contract = {
+    "schema_version": 1,
+    # The contracts `phase` field is the lifecycle STEP NAME per #251 spec.
+    # The validator uses this to look up the schema in its registry.
+    "phase": "code-review",
+    "status": os.environ["STATUS"],
+    "verdict": os.environ["VERDICT"],
+    "report_path": os.environ["REPORT"],
+    "critical_count": int(os.environ["CRIT"]),
+    "important_count": int(os.environ["IMP"]),
+    "suggestion_count": int(os.environ["SUG"]),
+    "fixed_in_pipeline": json.loads(os.environ["FIXED"]),
+    "deferred": json.loads(os.environ["DEFERRED"]),
+}
+json.dump(contract, open(os.environ["F"], "w"))
+print(f"[code-review] return_contract written to {os.environ[\"F\"]}")
+'
+```
+
+**No `[ -f "$F" ]` guard** — fresh-create JSON file, mirrors the verify-acceptance-criteria pattern (no state-file YAML mediation). After writing, return the contract path and the verdict as the consolidator's result text:
+
+`"Return contract written to <write_contract_to>. Verdict: <verdict> (critical=<N>, important=<N>, suggestion=<N>, deferred=<N>)."`
+
+The orchestrator (Pattern B wrapper in `skills/start/SKILL.md`) reads this path from the result string and runs `hooks/scripts/validate-return-contract.js` against it before proceeding.
 
 *(Turn Bridge Rule applies — call `TaskUpdate` immediately after outputting the code review report.)*

--- a/skills/start/references/code-review-pipeline.md
+++ b/skills/start/references/code-review-pipeline.md
@@ -402,10 +402,10 @@ When invoked from the Pattern B wrapper (`skills/start/SKILL.md` "Code Review â€
 - `schema_version`: `1`
 - `phase`: hardcoded `"code-review"`
 - `status`: `success` (clean pipeline, all critical+important addressed) | `partial` (deferred entries present OR remaining-after-2-iterations entries present) | `failed` (zero-agent guard fired, or consolidator could not assemble verdict)
-- `verdict`: `approve` (no critical, no `deferred[]`) | `needs_changes` (any critical OR any `deferred[]` present) | `blocked` (zero-agent guard, or pipeline cannot return a verdict)
+- `verdict`: `approve` (all critical and important findings fixed in pipeline, no `deferred[]` entries) | `needs_changes` (any unfixed critical or important findings remain, OR any `deferred[]` entry present) | `blocked` (zero-agent guard fired, or pipeline cannot return a verdict)
 - `report_path`: absolute path of the written report
-- `critical_count`, `important_count`, `suggestion_count`: integer counts across the entire pipeline (Phase 1a + 1b + 1c)
-- `fixed_in_pipeline`: array of `{severity: "critical|important|suggestion", summary: "<one-line>"}` for every finding addressed in Phase 1a auto-fix or Phase 3 single-pass fix
+- `critical_count`, `important_count`, `minor_count`: integer counts across the entire pipeline (Phase 1a + 1b + 1c)
+- `fixed_in_pipeline`: array of `{severity: "critical|important|minor", summary: "<one-line>"}` for every finding addressed in Phase 1a auto-fix or Phase 3 single-pass fix
 - `deferred`: array of `{severity, summary, reason}` for every Phase 4 row that mapped to deferral, plus any Minor-tier or unfixed-after-2-iterations entry the consolidator chose to surface in the contract
 
 Use the env-var-passing helper pattern (apostrophe-safe; mirrors `skills/verify-acceptance-criteria/SKILL.md` Step 6):
@@ -433,7 +433,7 @@ contract = {
     "report_path": os.environ["REPORT"],
     "critical_count": int(os.environ["CRIT"]),
     "important_count": int(os.environ["IMP"]),
-    "suggestion_count": int(os.environ["SUG"]),
+    "minor_count": int(os.environ["SUG"]),
     "fixed_in_pipeline": json.loads(os.environ["FIXED"]),
     "deferred": json.loads(os.environ["DEFERRED"]),
 }
@@ -444,7 +444,7 @@ print(f"[code-review] return_contract written to {os.environ[\"F\"]}")
 
 **No `[ -f "$F" ]` guard** â€” fresh-create JSON file, mirrors the verify-acceptance-criteria pattern (no state-file YAML mediation). After writing, return the contract path and the verdict as the consolidator's result text:
 
-`"Return contract written to <write_contract_to>. Verdict: <verdict> (critical=<N>, important=<N>, suggestion=<N>, deferred=<N>)."`
+`"Return contract written to <write_contract_to>. Verdict: <verdict> (critical=<N>, important=<N>, minor=<N>, deferred=<N>)."`
 
 The orchestrator (Pattern B wrapper in `skills/start/SKILL.md`) reads this path from the result string and runs `hooks/scripts/validate-return-contract.js` against it before proceeding.
 


### PR DESCRIPTION
## Summary

Wave 3 phase 5 of #251 — converts the **Code Review** lifecycle step to Pattern B subagent dispatch. Mirrors PR #264 (`verify-acceptance-criteria`) bucket-skip pattern.

- **Orchestrator retains:** Phase 0 (deterministic pre-filter) + Phase 1a (pr-review-toolkit) + Phase 1b (parallel report-only agents) + Phase 1c (senior panel). Subagents cannot recursively dispatch (#251 Q1), so the parallel reviewer fanout MUST stay orchestrator-side.
- **Consolidator subagent owns:** Phases 2-5 — conflict detection, single-pass fix application, targeted re-verification, report assembly, and contract write. Dispatched as `general-purpose` with `model: "sonnet"`.
- **Bucket-skip variant:** contract written directly to `/tmp/ff-code-review-contract-${SLUG}.json` (no `phase_summaries` bucket). The `implementation` slot is reserved for future Phase 6 (`subagent-driven-development`) Pattern B.

Locked contract: https://github.com/uta2000/feature-flow/issues/251#issuecomment-4366218476

## Per-phase implementation criteria (#251)

- [x] Phase's return contract specified inline in #251 (locked at [comment-4366218476](https://github.com/uta2000/feature-flow/issues/251#issuecomment-4366218476)) BEFORE PR opened
- [x] Dispatch wrapper includes explicit `model:` parameter (Sonnet for the consolidator)
- [x] Schema validation applied to the return value at the orchestrator boundary (`hooks/scripts/validate-return-contract.js` extended with `code-review` SCHEMAS entry; closed-enum check on `verdict`; per-item validation for `fixed_in_pipeline[]` and `deferred[]`)
- [x] Inline-fallback present in the conversion PR with explicit sunset version noted (vNEXT+1; 4 failure cases routing to inline pipeline)
- [ ] Measurement (#253) shows orchestrator context reduction on a real session — **deferred to post-merge** (mirrors the explicit deferral in PRs #263 and #264; baselines are pre-#262 JSONLs)
- [ ] Followup PR removes inline-fallback after two successful real-session uses

## Phase 4 changes (Pattern B)

Two targeted-check rows are deleted from `code-review-pipeline.md`:
1. `superpowers:code-reviewer rule 6 → run verify-acceptance-criteria`
2. `No Critical/Important findings → run verify-acceptance-criteria as baseline sanity check`

Both invocations are redundant — the Final Verification inline step runs verify-acceptance-criteria immediately after the code-review step. Inside the consolidator they would have failed anyway (verify-acceptance-criteria internally `Task()`s the task-verifier per PR #264; recursive dispatch silently fails per Q1).

**Agent re-dispatch → `deferred[]` mapping.** Inside the consolidator, agent re-dispatch is unavailable. Each Phase 4 row that would have triggered an agent re-dispatch instead writes a `deferred[]` entry to the return contract with `reason: "agent re-dispatch unavailable in Pattern B consolidator"`. **Verdict-honesty constraint:** the consolidator MUST NOT return `verdict: "approve"` while `deferred[]` is non-empty due to re-dispatch unavailability — verdict must be at least `needs_changes`. Inline-fallback mode runs the actual re-dispatch (orchestrator can dispatch); no `deferred[]` entries are written there.

## Phase 1c session-correlation token preserved

The `[session:$LIFECYCLE_SESSION]` token is passed to the consolidator in its dispatch prompt and stamped on every Phase 5 report entry — same requirement as inline mode, preserved across the Pattern B handoff so grep-correlation across pipeline phases, the Phase 5 report, and the PR body still works.

## Updated phase audit (after Wave 3 phase 5)

| Phase | Pattern | Status |
|---|---|---|
| `verify-plan-criteria` | A | ✅ Shipped #262; sunset pending (1 of 2 real-session uses captured) |
| `merge-prs` | A | ⏭ Skipped — no orchestrator-side benefit ([comment](https://github.com/uta2000/feature-flow/issues/251#issuecomment-4365149973)) |
| `design-document` | B | ✅ Shipped #263; sunset pending |
| `verify-acceptance-criteria` | B | ✅ Shipped #264; sunset pending |
| `code-review` | B | 🟡 Shipped this PR; awaiting review + merge + post-merge measurement |
| `implementation` | B | ⏳ Pending (Wave 3 phase 6) |
| `design-verification` | Inline | ✅ Already orchestrator-thin |

## Test plan

- [x] `node hooks/scripts/validate-return-contract.test.js` — 29/29 tests pass (7 new code-review test cases)
- [x] `bash hooks/scripts/validate-return-contract.e2e.sh` — 4/4 pipelines pass (verify-plan-criteria, design-document, verify-acceptance-criteria, code-review)
- [x] `node hooks/scripts/validate-return-contract.js hooks/scripts/fixtures/valid-code-review.json` exits 0
- [ ] Post-merge: real-session use of Pattern B code-review dispatch end-to-end + #253 measurement (deferred per #251 plan)
- [ ] After 2 successful real-session uses: open follow-up PR removing inline-fallback (sunset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)