### PR TITLE
fix(start): tighten verify-plan-criteria Pattern A wrapper against contract paraphrasing

### DIFF
--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -717,7 +717,7 @@ Task(
   subagent_type: "general-purpose",
   model: "sonnet",
   description: "verify-plan-criteria Pattern A",
-  prompt: "Invoke Skill(skill: 'feature-flow:verify-plan-criteria', args: 'yolo: true. plan_file: ${PLAN_PATH}. write_contract_to: ${STATE_FILE}. phase_id: plan'). Return the state-file path and a one-line summary of the contract."
+  prompt: "MUST invoke Skill(skill: 'feature-flow:verify-plan-criteria', args: 'yolo: true. plan_file: ${PLAN_PATH}. write_contract_to: ${STATE_FILE}. phase_id: plan'). Do NOT improvise the contract — Step 7 of the skill writes it for you. Required field values verbatim (no paraphrasing): phase MUST be \"verify-plan-criteria\" (not \"plan\"); status MUST be one of \"success\"|\"partial\"|\"failed\" (not \"passed\"|\"ok\"|\"complete\"); schema_version MUST be 1; plan_path, criteria_total, criteria_machine_verifiable, criteria_added_by_agent, tasks_missing_criteria all required (see hooks/scripts/validate-return-contract.js SCHEMAS map for the locked schema). Return the state-file path and a one-line summary of the contract."
 )
 ```
 


### PR DESCRIPTION
## Summary

- Tightens the verify-plan-criteria Pattern A wrapper prompt at `skills/start/SKILL.md:720` with explicit MUST-invoke language, a pointer to the skill's Step 7 (the canonical contract-writing site), and verbatim required field values (`phase`, `status` enum, `schema_version`).
- Surgical one-line change. No test churn — the wrapper is markdown-embedded.

## Why

PR #265's lifecycle session captured a real-session **failure** of `verify-plan-criteria` Pattern A (see [#251 comment-4366253961](https://github.com/uta2000/feature-flow/issues/251#issuecomment-4366253961) and the same issue's [Phase 6 skip comment](https://github.com/uta2000/feature-flow/issues/251#issuecomment-4366310664)): the dispatched subagent paraphrased the locked schema (`phase: "plan"` instead of `"verify-plan-criteria"`, `status: "passed"` instead of `"success"`, missing required fields). The validator caught it and the documented inline-fallback ran cleanly, but that's a real reliability gap — the terse wrapper prompt let the subagent treat the dispatch as *"produce a contract"* rather than *"invoke the skill that writes a contract."*

Pattern B wrappers (#263 / #264 / #265) already carry more guidance proportional to their contract complexity, which is why no equivalent failure has surfaced there. This PR brings Pattern A up to the same defensive bar with the smallest possible change.

## Sunset clock impact

This is a prerequisite for the `verify-plan-criteria` inline-fallback removal PR (the #262 sunset). Without this fix, two more successful real-session uses are uncertain — one already failed.

## Test plan

- [ ] `node hooks/scripts/validate-return-contract.test.js` still passes (no validator change; sanity check).
- [ ] On the next lifecycle that exercises `verify-plan-criteria` Pattern A, observe whether the dispatched subagent now writes a schema-compliant contract (validator exit 0) — counts as real-session use #2 of 2 for the #262 sunset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)