### PR TITLE
ci: run hook test suites and hooks.json validity check on every PR (#279)

### DIFF
--- a/.github/workflows/hook-tests.yml
+++ b/.github/workflows/hook-tests.yml
@@ -1,0 +1,44 @@
+name: Hook Tests
+
+# Runs the plugin's own hook test suites and validates the hook wiring file.
+# The hooks under hooks/scripts/ are safety-critical guardrail code (see #275);
+# this workflow is their regression net so a refactor cannot silently break them.
+#
+# POSIX-only: the suites include a bash e2e harness and /bin/sh fixtures, so this
+# runs on ubuntu-latest only. Windows runners are intentionally out of scope
+# while CI is Linux-only.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  hook-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run hook test suites
+        # Explicit failure accumulator instead of `set -e`: runs every suite (so
+        # CI surfaces all failures, not just the first) and fails if any suite
+        # exits non-zero — independent of the runner shell's `set -e` semantics.
+        run: |
+          rc=0
+          for f in hooks/scripts/*.test.js hooks/scripts/lib/*.test.js; do
+            [ -e "$f" ] || continue
+            echo "--- $f ---"
+            node "$f" || rc=1
+          done
+          exit $rc
+
+      - name: Validate hooks.json
+        run: python3 -c "import json; json.load(open('hooks/hooks.json'))"
+
+      - name: Run return-contract e2e harness
+        run: bash hooks/scripts/validate-return-contract.e2e.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the feature-flow plugin.
 
 ## [Unreleased]
 
+### Added
+- **CI runs the hook test suites + hooks.json validity check on every PR (#279)** — New `.github/workflows/hook-tests.yml` (separate from `check-references.yml`, which is left untouched so its behavior is unchanged) runs on `pull_request` and `push: main`. It executes all 12 hook test suites (`hooks/scripts/*.test.js` + `hooks/scripts/lib/*.test.js`), validates that `hooks/hooks.json` parses as JSON, and runs the `validate-return-contract.e2e.sh` integration harness. The safety-critical guardrail hooks fixed in #275 previously had zero automated regression coverage — a PR breaking every hook would still show a green check. POSIX/Linux-only (`ubuntu-latest`) by design: the suites include a bash e2e harness and `/bin/sh` fixtures; Windows runners are out of scope while CI is Linux-only. The test-suite step uses an explicit failure accumulator (`rc=1` on any non-zero suite, `exit $rc`) rather than `set -e`, so a failing suite fails the check independent of the runner shell's `set -e` loop semantics and CI surfaces every failing suite, not just the first.
+
 ## [1.38.0] - 2026-07-05
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds CI coverage for the plugin's own hook test suites — closing the gap where the safety-critical guardrail hooks fixed in #275 had **zero automated regression protection**. Before this, a PR that broke every hook would still show a green check.

New workflow `.github/workflows/hook-tests.yml` (runs on `pull_request` and `push: main`):
1. **Run hook test suites** — all 12 suites (`hooks/scripts/*.test.js` + `hooks/scripts/lib/*.test.js`)
2. **Validate hooks.json** — confirms the hook wiring file parses as JSON
3. **Return-contract e2e harness** — the `validate-return-contract.e2e.sh` integration test (optional per the issue; passes clean on main)

Kept as a **separate** workflow file so `check-references.yml` is untouched (AC #3 trivially true).

### Design note — why not `set -e`

The issue's original snippet used `set -e` in the loop. During implementation I found this is **shell-dependent**: `set -e` aborts a for-loop mid-iteration in bash but not in zsh, so a failing suite that sorts before a passing one could yield a *false green* depending on the shell — the exact bug class #275/#278 exist to kill. This PR uses an explicit failure accumulator (`rc=1` on any non-zero suite, `exit $rc`) instead, verified to fail correctly in **both** bash and zsh. Bonus: it runs every suite so CI surfaces *all* failures, not just the first.

Linux-only (`ubuntu-latest`) by design — the suites include a bash e2e harness and `/bin/sh` fixtures; Windows is out of scope while CI is Linux-only.

## Acceptance criteria

- [x] A PR that makes any `hooks/scripts/*.test.js` fail gets a red check — *verified: injected a genuinely-failing suite, accumulator returns exit 1 in both bash and zsh*
- [x] A PR introducing invalid JSON in `hooks/hooks.json` gets a red check — *verified: `python3 json.load` on malformed JSON exits 1*
- [x] Existing check-references behavior unchanged — *separate file; zero diff to `check-references.yml`*
- [x] Workflow green on current main — *every step simulated locally green (204 tests pass, hooks.json valid, e2e passes)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)